### PR TITLE
new: Add `native` platform to support React Native.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ provide sane defaults and configurations, verify package requirements, and much 
 
 ## Features
 
-- Configure packages for Node.js or Web browsers, with multiple output formats like CommonJS and
-  ECMAScript.
+- Configure packages for Node.js, Web browsers, or React Native, with multiple output formats like
+  CommonJS and ECMAScript.
 - Builds packages with Rollup to create self-contained and tree-shaken entry points. Provide the
   smallest file sizes possible!
 - Transforms packages with Babel's `preset-env` and the configured platform targets. Only ship and

--- a/src/BundleArtifact.ts
+++ b/src/BundleArtifact.ts
@@ -41,6 +41,8 @@ export default class BundleArtifact extends Artifact<BundleBuild> {
         platform = 'browser';
       } else if (platforms.includes('node')) {
         platform = 'node';
+      } else if (platforms.includes('native')) {
+        platform = 'native';
       }
     }
 

--- a/src/Package.ts
+++ b/src/Package.ts
@@ -172,7 +172,7 @@ export default class Package {
 
       if (formats.size === 0) {
         platforms.sort().forEach((platform) => {
-          if (platform === 'node') {
+          if (platform === 'native' || platform === 'node') {
             formats.add('lib');
           } else if (platform === 'browser') {
             formats.add('lib');

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -1,3 +1,4 @@
+import { TransformOptions } from '@babel/core';
 // eslint-disable-next-line unicorn/import-index
 import {
   BundleArtifact,
@@ -23,7 +24,7 @@ const featureFlags = project.rootPackage.getFeatureFlags();
 const inputConfig = getBabelInputConfig(artifact, featureFlags);
 const outputConfig = getBabelOutputConfig(artifact.builds[0], featureFlags);
 
-export const config = {
+export const config: TransformOptions = {
   babelrc: false,
   comments: false,
   // Input must come first
@@ -31,3 +32,12 @@ export const config = {
   // preset-env must come first
   presets: [...outputConfig.presets!, ...inputConfig.presets!],
 };
+
+if (platform === 'native') {
+  config.overrides = [
+    {
+      presets: ['@babel/preset-flow'],
+      test: /node_modules\/(react-native|@react-native|@react-native-community)/iu,
+    },
+  ];
+}

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -27,17 +27,14 @@ const outputConfig = getBabelOutputConfig(artifact.builds[0], featureFlags);
 export const config: TransformOptions = {
   babelrc: false,
   comments: false,
+  overrides: [
+    {
+      presets: ['@babel/preset-flow'],
+      test: /node_modules\/(react-native|@react-native|@react-native-community)/iu,
+    },
+  ],
   // Input must come first
   plugins: [...inputConfig.plugins!, ...outputConfig.plugins!],
   // preset-env must come first
   presets: [...outputConfig.presets!, ...inputConfig.presets!],
 };
-
-if (platform === 'native') {
-  config.overrides = [
-    {
-      presets: ['@babel/preset-flow'],
-      test: /node_modules\/(react-native|@react-native|@react-native-community)/iu,
-    },
-  ];
-}

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -30,7 +30,7 @@ export const config: TransformOptions = {
   overrides: [
     {
       presets: ['@babel/preset-flow'],
-      test: /node_modules\/(react-native|@react-native|@react-native-community)/iu,
+      test: /node_modules\/((jest-)?react-native|@react-native(-community)?)/iu,
     },
   ],
   // Input must come first

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -1,4 +1,3 @@
-import { TransformOptions } from '@babel/core';
 // eslint-disable-next-line unicorn/import-index
 import {
   BundleArtifact,
@@ -24,7 +23,7 @@ const featureFlags = project.rootPackage.getFeatureFlags();
 const inputConfig = getBabelInputConfig(artifact, featureFlags);
 const outputConfig = getBabelOutputConfig(artifact.builds[0], featureFlags);
 
-export const config: TransformOptions = {
+export const config = {
   babelrc: false,
   comments: false,
   overrides: [

--- a/src/babel/config.ts
+++ b/src/babel/config.ts
@@ -41,6 +41,12 @@ function getPlatformEnvOptions(
   }
 
   switch (platform) {
+    case 'browser':
+      return {
+        modules,
+        targets: { browsers: BROWSER_TARGETS[support] },
+      };
+
     case 'native':
       return {
         modules,
@@ -58,12 +64,6 @@ function getPlatformEnvOptions(
         targets: {
           node: process.env.NODE_ENV === 'test' ? 'current' : NODE_SUPPORTED_VERSIONS[support],
         },
-      };
-
-    case 'browser':
-      return {
-        modules,
-        targets: { browsers: BROWSER_TARGETS[support] },
       };
 
     default:
@@ -181,7 +181,7 @@ export function getBabelOutputConfig(
   }
 
   // Transform async/await into Promises for browsers
-  if (platform === 'browser') {
+  if (platform === 'browser' || platform === 'native') {
     plugins.push([
       resolve('babel-plugin-transform-async-to-promises'),
       { inlineHelpers: true, target: isFuture ? 'es6' : 'es5' },

--- a/src/babel/config.ts
+++ b/src/babel/config.ts
@@ -1,5 +1,5 @@
 import { PluginItem, TransformOptions as ConfigStructure } from '@babel/core';
-import { BROWSER_TARGETS, NODE_SUPPORTED_VERSIONS } from '../constants';
+import { BROWSER_TARGETS, NATIVE_TARGETS, NODE_SUPPORTED_VERSIONS } from '../constants';
 import { Support, Format, Platform, FeatureFlags, BundleBuild } from '../types';
 import BundleArtifact from '../BundleArtifact';
 
@@ -41,6 +41,12 @@ function getPlatformEnvOptions(
   }
 
   switch (platform) {
+    case 'native':
+      return {
+        modules,
+        targets: { browsers: NATIVE_TARGETS[support] },
+      };
+
     case 'node':
       return {
         // Async/await has been available since v7

--- a/src/components/Environment.tsx
+++ b/src/components/Environment.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { toArray } from '@boost/common';
 import { Style } from '@boost/cli';
-import { NODE_SUPPORTED_VERSIONS, BROWSER_TARGETS } from '../constants';
+import { NODE_SUPPORTED_VERSIONS, BROWSER_TARGETS, NATIVE_TARGETS } from '../constants';
 import { PackageConfig, Platform, Support } from '../types';
 
 export interface EnvironmentProps {
@@ -22,7 +22,9 @@ export function getVersionsCombo(platforms: Platform[], support: Support): Set<s
   const versions = new Set<string>();
 
   platforms.forEach((platform) => {
-    if (platform === 'node') {
+    if (platform === 'native') {
+      versions.add(`Native (${trimVersion(NATIVE_TARGETS[support])})`);
+    } else if (platform === 'node') {
       versions.add(`Node v${trimVersion(NODE_SUPPORTED_VERSIONS[support])}`);
     } else if (platform === 'browser') {
       const targets =

--- a/src/components/Init/PackageForm.tsx
+++ b/src/components/Init/PackageForm.tsx
@@ -57,8 +57,9 @@ export default function PackageForm({ onSubmit }: PackageFormProps) {
 
   const platformOptions = useMemo<SelectOptionLike<Platform>[]>(
     () => [
-      { label: 'Node', value: 'node' },
       { label: 'Browsers', value: 'browser' },
+      { label: 'Node', value: 'node' },
+      { label: 'React Native', value: 'native' },
     ],
     [],
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,6 +13,15 @@ export const EXCLUDE = [
   '*.(test|spec).(js|ts)x?',
 ];
 
+// https://reactnative.dev/docs/javascript-environment
+// Based on browserslist: https://github.com/browserslist/browserslist
+export const NATIVE_TARGETS: { [K in Support]: string } = {
+  legacy: 'iOS 8',
+  stable: 'iOS 10',
+  current: 'iOS 12',
+  experimental: 'iOS 14',
+};
+
 // Based on LTS schedule: https://nodejs.org/en/about/releases/
 export const NODE_SUPPORTED_VERSIONS: { [K in Support]: string } = {
   legacy: '8.10.0',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import { PackageStructure } from '@boost/common';
 
-export type Platform = 'native' | 'node' | 'browser'; // electron
+export type Platform = 'browser' | 'native' | 'node'; // electron
 
 export type Support =
   // Unsupported version
@@ -23,6 +23,8 @@ export type BrowserFormat =
   | 'esm'
   // Universal Module Definition with ".js" file extension
   | 'umd';
+
+export type NativeFormat = CommonFormat;
 
 export type NodeFormat =
   | CommonFormat

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import ts from 'typescript';
 import { PackageStructure } from '@boost/common';
 
-export type Platform = 'node' | 'browser'; // electron
+export type Platform = 'native' | 'node' | 'browser'; // electron
 
 export type Support =
   // Unsupported version

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -45,8 +45,9 @@ with caution.
 
 The platform in which built code will be ran.
 
-- `node` - Node.js runtime.
 - `browser` _(default)_ - Web browsers on desktop and mobile.
+- `native` - Native devices, primarily for React Native.
+- `node` - Node.js runtime.
 
 ```json
 {
@@ -89,14 +90,31 @@ The supported environments above map to the following platform targets.
 
 |            | Legacy    | Stable    | Current      | Experimental           |
 | ---------- | --------- | --------- | ------------ | ---------------------- |
+| Browser    | >= IE 10  | >= IE 11  | > 0.5% usage | last 2 chrome versions |
+| Native     | >= iOS 8  | >= iOS 10 | >= iOS 12    | >= iOS 14              |
 | Node       | >= 8.10.0 | >= 10.3.0 | >= 12.0.0    | >= 15.0.0              |
 | Node (NPM) | >= 5.6.0  | >= 6.1.0  | >= 6.9.0     | >= 7.0.0               |
-| Browser    | >= IE 10  | >= IE 11  | > 0.5% usage | last 2 chrome versions |
 
 ## Formats
 
 The output format for each platform build target. Each format will create a folder relative to the
 project root that will house the built files.
+
+### Browser
+
+- `lib` _(default)_ - [CommonJS](https://nodejs.org/api/modules.html) output using `.js` file
+  extension. For standard JavaScript and TypeScript projects.
+- `esm` _(default)_ - ECMAScript module output using `.js` file extension. The same as `lib`, but
+  uses `import/export` instead of `require`.
+- `umd` - Universal Module Definition output using `.js` file extension. Meant to be used directly
+  in the browser (via CDN) instead of being bundled. Will be automatically enabled if
+  [namespace](#namespace) is provided and using default formats.
+
+### Native
+
+- `lib` _(default)_ - [CommonJS](https://nodejs.org/api/modules.html) output using `.js` file
+  extension. For standard JavaScript and TypeScript projects. _This is the only format supported by
+  React Native and Metro._
 
 ### Node
 
@@ -106,16 +124,6 @@ project root that will house the built files.
   files must be written in CommonJS (`.cjs`) and `require` paths must use trailing extensions.
 - `mjs` - [ECMAScript module](https://nodejs.org/api/esm.html) output using `.mjs` file extension.
   Source files must be written in ESM (`.mjs`) and `import` paths must use trailing extensions.
-
-### Browser
-
-- `lib` _(default)_ - CommonJS output using `.js` file extension. For standard JavaScript and
-  TypeScript projects.
-- `esm` _(default)_ - ECMAScript module output using `.js` file extension. The same as `lib`, but
-  uses `import/export` instead of `require`.
-- `umd` - Universal Module Definition output using `.js` file extension. Meant to be used directly
-  in the browser (via CDN) instead of being bundled. Will be automatically enabled if
-  [namespace](#namespace) is provided and using default formats.
 
 ```json
 {

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -13,8 +13,8 @@ provide sane defaults and configurations, verify package requirements, and much 
 
 ## Features
 
-- Configure packages for Node.js or Web browsers, with multiple output formats like CommonJS and
-  ECMAScript.
+- Configure packages for Node.js, Web browsers, or React Native, with multiple output formats like
+  CommonJS and ECMAScript.
 - Builds packages with Rollup to create self-contained and tree-shaken entry points. Provide the
   smallest file sizes possible!
 - Transforms packages with Babel's `preset-env` and the configured platform targets. Only ship and

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -47,8 +47,8 @@ const features: FeatureProps[][] = [
       title: '🌐 Stable environments',
       description: (
         <>
-          Supported browser targets and Node.js versions are carefully crafted to provide long term
-          support and stability, with the ability to experiment.
+          Supported browser targets, React Native targets, and Node.js versions are carefully
+          crafted to provide long term support and stability, with the ability to experiment.
         </>
       ),
     },


### PR DESCRIPTION
This is rather simple as we only need to target JavaScriptCore (which is what iOS Safari uses).