### PR TITLE
new: Add custom Babel plugin to transform environment expressions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "type": "beemo typescript --noEmit",
     "prerelease": "yarn run ci && yarn run setup && yarn run pack",
     "pack": "NODE_ENV=production yarn run packemon pack --addEngines --generateDeclaration=api",
-    "packemon": "node ./build/bin.js"
+    "packemon": "node ./packemon.js"
   },
   "repository": "https://github.com/milesj/packemon.git",
   "author": "Miles Johnson",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.1",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
-    "babel-plugin-transform-dev": "^2.0.1",
     "builtin-modules": "^3.2.0",
     "chokidar": "^3.4.3",
     "execa": "^5.0.0",

--- a/packemon.js
+++ b/packemon.js
@@ -1,0 +1,7 @@
+/* eslint-disable no-underscore-dangle */
+
+global.__DEV__ = true;
+global.__PROD__ = false;
+global.__TEST__ = false;
+
+require('./build/bin');

--- a/src/TypesArtifact.ts
+++ b/src/TypesArtifact.ts
@@ -116,7 +116,7 @@ export default class TypesArtifact extends Artifact<TypesBuild> {
 
     // Extract all DTS into a single file
     const result = Extractor.invoke(ExtractorConfig.loadFileAndPrepare(configPath), {
-      localBuild: process.env.NODE_ENV !== 'production',
+      localBuild: __DEV__,
       messageCallback: (warn) => {
         // eslint-disable-next-line no-param-reassign
         warn.handled = true;

--- a/src/babel/plugins/envExpressions.ts
+++ b/src/babel/plugins/envExpressions.ts
@@ -1,0 +1,53 @@
+import { types as t, NodePath } from '@babel/core';
+
+const exprs = {
+  __DEV__: ['!==', 'production'],
+  __PROD__: ['===', 'production'],
+  __TEST__: ['===', 'test'],
+};
+
+export default function envExpressions() {
+  return {
+    visitor: {
+      Identifier: {
+        enter(path: NodePath<t.Identifier>) {
+          Object.entries(exprs).forEach(([expr, [op, env]]) => {
+            if (
+              path.isIdentifier({ name: expr }) &&
+              // const __DEV__ = var;
+              !path.parentPath.isVariableDeclarator() &&
+              // { __DEV__: var }
+              !path.parentPath.isObjectProperty() &&
+              // obj.__DEV__ = var;
+              !path.parentPath.isMemberExpression()
+              // // if (__DEV__)
+              // (path.parentPath.isIfStatement() ||
+              //   // switch(__DEV__)
+              //   path.parentPath.isSwitchStatement() ||
+              //   // __DEV__ && var
+              //   path.parentPath.isLogicalExpression() ||
+              //   // __DEV__ ? a : b
+              //   path.parentPath.isConditionalExpression() ||
+              //   // !__DEV__
+              //   path.parentPath.isUnaryExpression() ||
+              //   // prop={__DEV__}
+              //   path.parentPath.isJSXExpressionContainer())
+            ) {
+              path.replaceWith(
+                t.binaryExpression(
+                  op as '===',
+                  t.memberExpression(
+                    t.memberExpression(t.identifier('process'), t.identifier('env'), false),
+                    t.identifier('NODE_ENV'),
+                    false,
+                  ),
+                  t.stringLiteral(env),
+                ),
+              );
+            }
+          });
+        },
+      },
+    },
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,13 @@
+/* eslint-disable no-underscore-dangle */
+
 import ts from 'typescript';
 import { PackageStructure } from '@boost/common';
+
+declare global {
+  const __DEV__: boolean;
+  const __PROD__: boolean;
+  const __TEST__: boolean;
+}
 
 export type Platform = 'browser' | 'native' | 'node'; // electron
 

--- a/website/docs/build.md
+++ b/website/docs/build.md
@@ -179,8 +179,9 @@ The following plugins are enabled when one of their conditions are met.
 - `babel-plugin-transform-async-to-promises`
   - Enabled when package [platform](./config.md#platforms) is configured to `browser`. This attempts
     to _avoid_ `regenerator-runtime` by transforming async/await to promises.
-- `babel-plugin-transform-dev`
-  - Always enabled. Will transform `__DEV__` to `process.env.NODE_ENV` conditionals.
+- _Custom_
+  - Always enabled. Will transform `__DEV__`, `__PROD__`, and `__TEST__` to `process.env.NODE_ENV`
+    conditionals.
 
 ## Rollup configuration
 


### PR DESCRIPTION
Support `__DEV__`, `__PROD__`, and `__TEST__` natively.