### PR TITLE
fix: Improve bundle build separation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "@types/node": "^14.14.25",
     "@types/react": "^16.9.56",
     "@types/rimraf": "^3.0.0",
-    "@types/semver": "^7.3.4"
+    "@types/semver": "^7.3.4",
+    "chokidar": "^3.5.1"
   },
   "dependencies": {
     "@babel/core": "^7.12.13",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "rollup-plugin-visualizer": "^4.2.0",
     "semver": "^7.3.4",
     "spdx-license-list": "^6.4.0",
-    "string-hash": "^1.1.3",
     "typescript": "^4.1.3"
   },
   "optionalDependencies": {

--- a/src/BundleArtifact.ts
+++ b/src/BundleArtifact.ts
@@ -27,29 +27,6 @@ export default class BundleArtifact extends Artifact<BundleBuild> {
 
   protected debug!: Debugger;
 
-  static generateBuild(format: Format, support: Support, platforms: Platform[]): BundleBuild {
-    let platform: Platform;
-
-    if (format === 'cjs' || format === 'mjs') {
-      platform = 'node';
-    } else if (format === 'esm' || format === 'umd' || platforms.length === 0) {
-      platform = 'browser';
-      // Order by lowest platform
-    } else if (platforms.includes('browser')) {
-      platform = 'browser';
-    } else if (platforms.includes('native')) {
-      platform = 'native';
-    } else {
-      platform = 'node';
-    }
-
-    return {
-      format,
-      platform,
-      support,
-    };
-  }
-
   startup() {
     this.debug = createDebugger(['packemon', 'bundle', this.package.getSlug(), this.outputName]);
   }

--- a/src/BundleArtifact.ts
+++ b/src/BundleArtifact.ts
@@ -1,5 +1,4 @@
 import { rollup, RollupCache } from 'rollup';
-import hash from 'string-hash';
 import { isObject, Path, SettingMap, toArray } from '@boost/common';
 import { createDebugger, Debugger } from '@boost/debug';
 import Artifact from './Artifact';
@@ -135,7 +134,7 @@ export default class BundleArtifact extends Artifact<BundleBuild> {
   }
 
   getStatsFileName(): string {
-    return `stats-${hash(this.getStatsTitle()).toString(16)}.html`;
+    return `stats-${this.getStatsTitle().replace(/\//gu, '-')}.html`;
   }
 
   getStatsTitle(): string {

--- a/src/Package.ts
+++ b/src/Package.ts
@@ -172,30 +172,47 @@ export default class Package {
         name: this.getName(),
       });
 
-      const platforms = toArray(config.platform);
-      const formats = new Set(toArray(config.format));
+      toArray(config.platform).forEach((platform) => {
+        let formats = [...toArray(config.format)];
+        const isEmpty = formats.length === 0;
 
-      if (formats.size === 0) {
-        platforms.sort().forEach((platform) => {
-          if (platform === 'native' || platform === 'node') {
-            formats.add('lib');
-          } else if (platform === 'browser') {
-            formats.add('lib');
-            formats.add('esm');
-
-            if (config.namespace) {
-              formats.add('umd');
+        switch (platform) {
+          case 'native':
+            if (isEmpty) {
+              formats.push('lib');
+            } else {
+              formats = formats.filter(format => )
             }
-          }
-        });
-      }
+            break;
 
-      this.configs.push({
-        formats: Array.from(formats),
-        inputs: config.inputs,
-        namespace: config.namespace,
-        platforms,
-        support: config.support,
+          case 'node':
+            break;
+
+          case 'browser':
+          default:
+            break;
+        }
+
+        if (platform === 'native') {
+          formats.push('lib');
+        } else if (platform === 'node') {
+          formats.push('lib');
+        } else if (platform === 'browser') {
+          formats.push('lib');
+          formats.push('esm');
+
+          if (config.namespace) {
+            formats.push('umd');
+          }
+        }
+
+        this.configs.push({
+          formats,
+          inputs: config.inputs,
+          namespace: config.namespace,
+          platform,
+          support: config.support,
+        });
       });
     });
   }

--- a/src/Package.ts
+++ b/src/Package.ts
@@ -5,6 +5,7 @@ import ts from 'typescript';
 import { Memoize, optimal, Path, toArray } from '@boost/common';
 import { createDebugger, Debugger } from '@boost/debug';
 import Artifact from './Artifact';
+import { FORMATS_BROWSER, FORMATS_NATIVE, FORMATS_NODE } from './constants';
 import Project from './Project';
 import { packemonBlueprint } from './schemas';
 import {
@@ -181,29 +182,31 @@ export default class Package {
             if (isEmpty) {
               formats.push('lib');
             } else {
-              formats = formats.filter(format => )
+              formats = formats.filter((format) => (FORMATS_NATIVE as string[]).includes(format));
             }
             break;
 
           case 'node':
+            if (isEmpty) {
+              formats.push('lib');
+            } else {
+              formats = formats.filter((format) => (FORMATS_NODE as string[]).includes(format));
+            }
             break;
 
           case 'browser':
           default:
+            if (isEmpty) {
+              formats.push('lib');
+              formats.push('esm');
+
+              if (config.namespace) {
+                formats.push('umd');
+              }
+            } else {
+              formats = formats.filter((format) => (FORMATS_BROWSER as string[]).includes(format));
+            }
             break;
-        }
-
-        if (platform === 'native') {
-          formats.push('lib');
-        } else if (platform === 'node') {
-          formats.push('lib');
-        } else if (platform === 'browser') {
-          formats.push('lib');
-          formats.push('esm');
-
-          if (config.namespace) {
-            formats.push('umd');
-          }
         }
 
         this.configs.push({

--- a/src/Packemon.ts
+++ b/src/Packemon.ts
@@ -201,16 +201,16 @@ export default class Packemon {
       const typesBuilds: Record<string, TypesBuild> = {};
       const sharedLib = this.requiresSharedLib(pkg);
 
-      console.log({ sharedLib });
-
       pkg.configs.forEach((config, index) => {
         Object.entries(config.inputs).forEach(([outputName, inputFile]) => {
           const artifact = new BundleArtifact(
             pkg,
             // Must be unique per input to avoid references
-            config.formats.map((format) =>
-              BundleArtifact.generateBuild(format, config.support, config.platforms),
-            ),
+            config.formats.map((format) => ({
+              format,
+              support: config.support,
+              platform: config.platform,
+            })),
           );
           artifact.configGroup = index;
           artifact.inputFile = inputFile;
@@ -268,9 +268,7 @@ export default class Packemon {
     let libFormatCount = 0;
 
     pkg.configs.forEach((config) => {
-      config.platforms.forEach((platform) => {
-        platformsToCheck.add(platform);
-      });
+      platformsToCheck.add(config.platform);
 
       config.formats.forEach((format) => {
         if (format === 'lib') {

--- a/src/Packemon.ts
+++ b/src/Packemon.ts
@@ -205,18 +205,20 @@ export default class Packemon {
         Object.entries(config.inputs).forEach(([outputName, inputFile]) => {
           const artifact = new BundleArtifact(
             pkg,
-            // Must be unique per input to avoid references
+            // Pass platform and support here for convenience
             config.formats.map((format) => ({
               format,
-              support: config.support,
               platform: config.platform,
+              support: config.support,
             })),
           );
           artifact.configGroup = index;
           artifact.inputFile = inputFile;
           artifact.outputName = outputName;
           artifact.namespace = config.namespace;
+          artifact.platform = config.platform;
           artifact.sharedLib = sharedLib;
+          artifact.support = config.support;
 
           pkg.addArtifact(artifact);
 

--- a/src/Packemon.ts
+++ b/src/Packemon.ts
@@ -201,6 +201,8 @@ export default class Packemon {
       const typesBuilds: Record<string, TypesBuild> = {};
       const sharedLib = this.requiresSharedLib(pkg);
 
+      console.log({ sharedLib });
+
       pkg.configs.forEach((config, index) => {
         Object.entries(config.inputs).forEach(([outputName, inputFile]) => {
           const artifact = new BundleArtifact(
@@ -277,7 +279,7 @@ export default class Packemon {
       });
     });
 
-    return platformsToCheck.size > 1 && libFormatCount > 1;
+    return platformsToCheck.size > 1 && libFormatCount >= 1;
   }
 
   /**

--- a/src/Packemon.ts
+++ b/src/Packemon.ts
@@ -279,7 +279,7 @@ export default class Packemon {
       });
     });
 
-    return platformsToCheck.size > 1 && libFormatCount >= 1;
+    return platformsToCheck.size > 1 && libFormatCount > 1;
   }
 
   /**

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -40,7 +40,9 @@ export function createConfig(folder: string): ConfigStructure {
   // Create package and configs
   const pkg = new Package(project, path, contents);
 
-  pkg.setConfigs(toArray(pkg.packageJson.packemon));
+  if (pkg.packageJson.packemon) {
+    pkg.setConfigs(toArray(pkg.packageJson.packemon));
+  }
 
   // Determine the lowest platform to support
   const platforms = pkg.configs.map((config) => config.platform);
@@ -53,14 +55,15 @@ export function createConfig(folder: string): ConfigStructure {
   }
 
   // Generate artifact and builds
-  const artifact = new BundleArtifact(pkg, [{ format, support, platform: lowestPlatform }]);
+  const artifact = new BundleArtifact(pkg, [{ format, platform: lowestPlatform, support }]);
+  artifact.platform = lowestPlatform;
+  artifact.support = support;
 
   return getBabelConfig(artifact, pkg.getFeatureFlags());
 }
 
 export function createRootConfig(): ConfigStructure {
-  const artifact = new BundleArtifact(project.rootPackage, [{ format, platform: 'node', support }]);
-  const config = getBabelConfig(artifact, project.rootPackage.getFeatureFlags());
+  const config = createConfig(process.cwd());
 
   return {
     ...config,

--- a/src/commands/Watch.tsx
+++ b/src/commands/Watch.tsx
@@ -26,7 +26,7 @@ export class WatchCommand extends BaseCommand<WatchOptions> {
 
   async run() {
     const { packemon } = this;
-    const chokidar = this.loadChokidar();
+    const chokidar = this.loadChokidar() as typeof import('chokidar');
 
     packemon.debug('Starting `watch` process');
 
@@ -70,10 +70,10 @@ export class WatchCommand extends BaseCommand<WatchOptions> {
     }
   }
 
-  loadChokidar() {
+  loadChokidar(): unknown {
     try {
       // eslint-disable-next-line global-require, import/no-extraneous-dependencies
-      return require('chokidar') as typeof import('chokidar');
+      return require('chokidar');
     } catch {
       throw new Error(
         'Chokidar is required for file watching. Please install with `yarn add --dev chokidar`.',

--- a/src/components/ArtifactList.tsx
+++ b/src/components/ArtifactList.tsx
@@ -15,7 +15,7 @@ export default function ArtifactList({ artifacts = [], environment }: ArtifactLi
     <>
       {!!environment && (
         <Box marginLeft={1}>
-          <Environment target={environment} />
+          <Environment type={environment} />
         </Box>
       )}
 

--- a/src/components/Environment.tsx
+++ b/src/components/Environment.tsx
@@ -9,7 +9,7 @@ export type EnvironmentProps =
       platform: Platform;
       support: Support;
     }
-  | { target: EnvType };
+  | { type: EnvType };
 
 function trimVersion(version: string) {
   const parts = version.split('.');
@@ -44,8 +44,8 @@ export default function Environment(props: EnvironmentProps) {
   let platform: string;
   let support: string;
 
-  if ('target' in props) {
-    [platform, support] = props.target.split(':');
+  if ('type' in props) {
+    [platform, support] = props.type.split(':');
   } else {
     ({ platform, support } = props);
   }

--- a/src/components/PackageRow.tsx
+++ b/src/components/PackageRow.tsx
@@ -25,7 +25,7 @@ export default function PackageRow({ package: pkg }: PackageRowProps) {
 
         {envs.length === 1 && (
           <Box marginLeft={1}>
-            <Environment target={envs[0]} />
+            <Environment type={envs[0]} />
           </Box>
         )}
       </Box>

--- a/src/components/hooks/useGroupedArtifacts.ts
+++ b/src/components/hooks/useGroupedArtifacts.ts
@@ -12,13 +12,11 @@ export default function useGroupedArtifacts(pkg: Package) {
     // Group artifacts by platform and support
     pkg.artifacts.forEach((artifact) => {
       if (artifact instanceof BundleArtifact) {
-        artifact.builds.forEach((build) => {
-          const key = `${build.platform}:${build.support}` as Environment;
-          const set = groups[key] || new Set();
+        const key = `${artifact.platform}:${artifact.support}` as Environment;
+        const set = groups[key] || new Set();
 
-          set.add(artifact);
-          groups[key] = set;
-        });
+        set.add(artifact);
+        groups[key] = set;
       } else {
         ungrouped.push(artifact);
       }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,13 @@
 import { StyleType } from '@boost/cli';
-import { ArtifactState, Format, Platform, Support } from './types';
+import {
+  ArtifactState,
+  BrowserFormat,
+  Format,
+  NativeFormat,
+  NodeFormat,
+  Platform,
+  Support,
+} from './types';
 
 export const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'];
 
@@ -60,8 +68,20 @@ export const STATE_LABELS: { [K in ArtifactState]: string } = {
 
 export const DEFAULT_FORMAT: Format = 'lib';
 
+export const FORMATS_BROWSER: BrowserFormat[] = ['lib', 'esm', 'umd'];
+
+export const FORMATS_NATIVE: NativeFormat[] = ['lib'];
+
+export const FORMATS_NODE: NodeFormat[] = ['lib', 'mjs', 'cjs'];
+
+export const FORMATS: Format[] = ['lib', 'esm', 'umd', 'mjs', 'cjs'];
+
 export const DEFAULT_INPUT = 'src/index.ts';
 
 export const DEFAULT_PLATFORM: Platform = 'browser';
 
+export const PLATFORMS: Platform[] = ['native', 'node', 'browser'];
+
 export const DEFAULT_SUPPORT: Support = 'stable';
+
+export const SUPPORTS: Support[] = ['legacy', 'stable', 'current', 'experimental'];

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -85,7 +85,7 @@ export function getRollupOutputConfig(
 ): OutputOptions {
   const { format, platform, support } = build;
   const name = artifact.outputName;
-  const { ext, folder } = artifact.getOutputMetadata(format, platform);
+  const { ext, folder } = artifact.getOutputMetadata(format);
 
   const output: OutputOptions = {
     dir: artifact.package.path.append(folder).path(),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,5 +1,15 @@
 import { Blueprint, predicates, toArray } from '@boost/common';
-import { DEFAULT_FORMAT, DEFAULT_INPUT, DEFAULT_PLATFORM, DEFAULT_SUPPORT } from './constants';
+import {
+  DEFAULT_FORMAT,
+  DEFAULT_INPUT,
+  DEFAULT_PLATFORM,
+  DEFAULT_SUPPORT,
+  FORMATS,
+  FORMATS_BROWSER,
+  FORMATS_NATIVE,
+  FORMATS_NODE,
+  PLATFORMS,
+} from './constants';
 import {
   AnalyzeType,
   BrowserFormat,
@@ -18,16 +28,16 @@ const { array, bool, number, object, string, union } = predicates;
 
 // PLATFORMS
 
-const platform = string<Platform>(DEFAULT_PLATFORM).oneOf(['native', 'node', 'browser']);
+const platform = string<Platform>(DEFAULT_PLATFORM).oneOf(PLATFORMS);
 
 // FORMATS
 
-const nativeFormat = string<NativeFormat>(DEFAULT_FORMAT).oneOf(['lib']);
-const nodeFormat = string<NodeFormat>(DEFAULT_FORMAT).oneOf(['lib', 'mjs', 'cjs']);
-const browserFormat = string<BrowserFormat>(DEFAULT_FORMAT).oneOf(['lib', 'esm', 'umd']);
+const nativeFormat = string<NativeFormat>(DEFAULT_FORMAT).oneOf(FORMATS_NATIVE);
+const nodeFormat = string<NodeFormat>(DEFAULT_FORMAT).oneOf(FORMATS_NODE);
+const browserFormat = string<BrowserFormat>(DEFAULT_FORMAT).oneOf(FORMATS_BROWSER);
 
 const format = string<Format>(DEFAULT_FORMAT)
-  .oneOf(['lib', 'esm', 'umd', 'mjs', 'cjs'])
+  .oneOf(FORMATS)
   .custom<PackemonPackageConfig>((value, schema) => {
     const platforms = new Set(toArray(schema.struct.platform));
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,7 +74,7 @@ export interface PackageConfig {
   formats: Format[];
   inputs: Record<string, string>;
   namespace: string;
-  platforms: Platform[];
+  platform: Platform;
   support: Support;
 }
 

--- a/tests/BundleArtifact.test.ts
+++ b/tests/BundleArtifact.test.ts
@@ -51,7 +51,7 @@ describe('BundleArtifact', () => {
     expect(artifact.getBuildTargets()).toEqual(['lib', 'cjs']);
     expect(artifact.toString()).toBe('bundle:index (lib, cjs)');
     expect(artifact.getStatsTitle()).toBe('project/index');
-    expect(artifact.getStatsFileName()).toBe('stats-e000d9e1.html');
+    expect(artifact.getStatsFileName()).toBe('stats-project-index.html');
   });
 
   describe('build()', () => {
@@ -442,7 +442,7 @@ describe('BundleArtifact', () => {
     it('removes visualizer HTML files', async () => {
       await artifact.cleanup();
 
-      expect(fs.remove).toHaveBeenCalledWith(fixturePath.append('stats-e000d9e1.html').path());
+      expect(fs.remove).toHaveBeenCalledWith(fixturePath.append('stats-project-index.html').path());
     });
   });
 

--- a/tests/BundleArtifact.test.ts
+++ b/tests/BundleArtifact.test.ts
@@ -122,6 +122,7 @@ describe('BundleArtifact', () => {
   describe('postBuild()', () => {
     describe('entry points', () => {
       it('adds "main" for `lib` format', () => {
+        artifact.platform = 'browser';
         artifact.builds.push({ format: 'lib', platform: 'browser', support: 'stable' });
 
         expect(artifact.package.packageJson).toEqual(packageJson);
@@ -136,6 +137,7 @@ describe('BundleArtifact', () => {
 
       it('adds "main" for `lib` format and shared lib required', () => {
         artifact.sharedLib = true;
+        artifact.platform = 'browser';
         artifact.builds.push({ format: 'lib', platform: 'browser', support: 'stable' });
 
         expect(artifact.package.packageJson).toEqual(packageJson);
@@ -265,7 +267,8 @@ describe('BundleArtifact', () => {
     });
 
     describe('engines', () => {
-      it('does nothing if no `node` build', () => {
+      it('does nothing if builds is not `node`', () => {
+        artifact.platform = 'browser';
         artifact.builds.push({ format: 'lib', platform: 'browser', support: 'stable' });
 
         expect(artifact.package.packageJson.engines).toBeUndefined();
@@ -310,23 +313,6 @@ describe('BundleArtifact', () => {
           packemon: '*',
           node: '>=10.3.0',
           npm: '>=6.1.0',
-        });
-      });
-
-      it('adds lowest versions when multiple `node` builds exist', () => {
-        artifact.builds.push(
-          { format: 'lib', platform: 'node', support: 'stable' },
-          { format: 'lib', platform: 'node', support: 'legacy' },
-          { format: 'lib', platform: 'node', support: 'experimental' },
-        );
-
-        expect(artifact.package.packageJson.engines).toBeUndefined();
-
-        artifact.postBuild({ addEngines: true });
-
-        expect(artifact.package.packageJson.engines).toEqual({
-          node: '>=8.10.0',
-          npm: '>=5.6.0 || >=6.0.0',
         });
       });
     });
@@ -475,8 +461,12 @@ describe('BundleArtifact', () => {
   });
 
   describe('getOutputMetadata()', () => {
+    beforeEach(() => {
+      artifact.platform = 'node';
+    });
+
     it('returns metadata for `lib` format', () => {
-      expect(artifact.getOutputMetadata('lib', 'node')).toEqual({
+      expect(artifact.getOutputMetadata('lib')).toEqual({
         ext: 'js',
         file: 'index.js',
         folder: 'lib',
@@ -485,7 +475,7 @@ describe('BundleArtifact', () => {
     });
 
     it('returns metadata for `esm` format', () => {
-      expect(artifact.getOutputMetadata('esm', 'node')).toEqual({
+      expect(artifact.getOutputMetadata('esm')).toEqual({
         ext: 'js',
         file: 'index.js',
         folder: 'esm',
@@ -494,7 +484,7 @@ describe('BundleArtifact', () => {
     });
 
     it('returns metadata for `umd` format', () => {
-      expect(artifact.getOutputMetadata('umd', 'node')).toEqual({
+      expect(artifact.getOutputMetadata('umd')).toEqual({
         ext: 'js',
         file: 'index.js',
         folder: 'umd',
@@ -503,7 +493,7 @@ describe('BundleArtifact', () => {
     });
 
     it('returns metadata for `cjs` format', () => {
-      expect(artifact.getOutputMetadata('cjs', 'node')).toEqual({
+      expect(artifact.getOutputMetadata('cjs')).toEqual({
         ext: 'cjs',
         file: 'index.cjs',
         folder: 'cjs',
@@ -512,7 +502,7 @@ describe('BundleArtifact', () => {
     });
 
     it('returns metadata for `mjs` format', () => {
-      expect(artifact.getOutputMetadata('mjs', 'node')).toEqual({
+      expect(artifact.getOutputMetadata('mjs')).toEqual({
         ext: 'mjs',
         file: 'index.mjs',
         folder: 'mjs',
@@ -524,7 +514,7 @@ describe('BundleArtifact', () => {
       it('includes platform in folder when shared lib required', () => {
         artifact.sharedLib = true;
 
-        expect(artifact.getOutputMetadata('lib', 'node')).toEqual({
+        expect(artifact.getOutputMetadata('lib')).toEqual({
           ext: 'js',
           file: 'index.js',
           folder: 'lib/node',
@@ -535,7 +525,7 @@ describe('BundleArtifact', () => {
       it('ignores shared lib if not `lib` format', () => {
         artifact.sharedLib = true;
 
-        expect(artifact.getOutputMetadata('esm', 'node')).toEqual({
+        expect(artifact.getOutputMetadata('esm')).toEqual({
           ext: 'js',
           file: 'index.js',
           folder: 'esm',

--- a/tests/BundleArtifact.test.ts
+++ b/tests/BundleArtifact.test.ts
@@ -54,56 +54,6 @@ describe('BundleArtifact', () => {
     expect(artifact.getStatsFileName()).toBe('stats-e000d9e1.html');
   });
 
-  describe('.generateBuild()', () => {
-    it('returns combination as-is when no overrides are necessary', () => {
-      expect(BundleArtifact.generateBuild('lib', 'stable', ['browser'])).toEqual({
-        format: 'lib',
-        platform: 'browser',
-        support: 'stable',
-      });
-    });
-
-    it('returns `browser` platform if none provided', () => {
-      expect(BundleArtifact.generateBuild('lib', 'stable', [])).toEqual({
-        format: 'lib',
-        platform: 'browser',
-        support: 'stable',
-      });
-    });
-
-    it('forces platform to `node` if format is `cjs`', () => {
-      expect(BundleArtifact.generateBuild('cjs', 'current', ['browser'])).toEqual({
-        format: 'cjs',
-        platform: 'node',
-        support: 'current',
-      });
-    });
-
-    it('forces platform to `node` if format is `mjs`', () => {
-      expect(BundleArtifact.generateBuild('mjs', 'experimental', ['browser'])).toEqual({
-        format: 'mjs',
-        platform: 'node',
-        support: 'experimental',
-      });
-    });
-
-    it('forces platform to `browser` if format is `esm`', () => {
-      expect(BundleArtifact.generateBuild('esm', 'legacy', ['node'])).toEqual({
-        format: 'esm',
-        platform: 'browser',
-        support: 'legacy',
-      });
-    });
-
-    it('forces platform to `browser` if format is `umd`', () => {
-      expect(BundleArtifact.generateBuild('umd', 'stable', ['node'])).toEqual({
-        format: 'umd',
-        platform: 'browser',
-        support: 'stable',
-      });
-    });
-  });
-
   describe('build()', () => {
     let bundleWriteSpy: jest.SpyInstance;
 

--- a/tests/Package.test.ts
+++ b/tests/Package.test.ts
@@ -315,7 +315,7 @@ describe('Package', () => {
         {
           formats: ['lib', 'esm'],
           inputs: {},
-          platforms: ['browser'],
+          platform: 'browser',
           namespace: '',
           support: 'stable',
         },
@@ -337,7 +337,7 @@ describe('Package', () => {
         {
           formats: ['lib', 'esm', 'umd'],
           inputs: {},
-          platforms: ['browser'],
+          platform: 'browser',
           namespace: 'test',
           support: 'stable',
         },
@@ -359,7 +359,7 @@ describe('Package', () => {
         {
           formats: ['lib'],
           inputs: {},
-          platforms: ['native'],
+          platform: 'native',
           namespace: '',
           support: 'stable',
         },
@@ -381,7 +381,7 @@ describe('Package', () => {
         {
           formats: ['lib'],
           inputs: {},
-          platforms: ['node'],
+          platform: 'node',
           namespace: '',
           support: 'stable',
         },
@@ -403,7 +403,67 @@ describe('Package', () => {
         {
           formats: ['cjs', 'mjs'],
           inputs: {},
-          platforms: ['node'],
+          platform: 'node',
+          namespace: '',
+          support: 'stable',
+        },
+      ]);
+    });
+
+    it('sets default formats for multiple platforms', () => {
+      pkg.setConfigs([
+        {
+          inputs: {},
+          platform: ['browser', 'node'],
+        },
+      ]);
+
+      expect(pkg.configs).toEqual([
+        {
+          formats: ['lib', 'esm'],
+          inputs: {},
+          platform: 'browser',
+          namespace: '',
+          support: 'stable',
+        },
+        {
+          formats: ['lib'],
+          inputs: {},
+          platform: 'node',
+          namespace: '',
+          support: 'stable',
+        },
+      ]);
+    });
+
+    it('filters and divides formats for multiple platforms', () => {
+      pkg.setConfigs([
+        {
+          format: ['lib', 'esm', 'cjs'],
+          inputs: {},
+          platform: ['browser', 'node', 'native'],
+        },
+      ]);
+
+      expect(pkg.configs).toEqual([
+        {
+          formats: ['lib', 'esm'],
+          inputs: {},
+          platform: 'browser',
+          namespace: '',
+          support: 'stable',
+        },
+        {
+          formats: ['lib', 'cjs'],
+          inputs: {},
+          platform: 'node',
+          namespace: '',
+          support: 'stable',
+        },
+        {
+          formats: ['lib'],
+          inputs: {},
+          platform: 'native',
           namespace: '',
           support: 'stable',
         },

--- a/tests/Packemon.test.ts
+++ b/tests/Packemon.test.ts
@@ -419,14 +419,21 @@ describe('Packemon', () => {
       ]);
     });
 
-    it.only('generates build artifacts for projects with multiple platforms', async () => {
+    it('generates build artifacts for projects with multiple platforms', async () => {
       packemon = new Packemon(getFixturePath('project-multi-platform'));
 
       const packages = await packemon.loadConfiguredPackages();
 
       packemon.generateArtifacts(packages);
 
-      console.log(packages[0].configs, packages[0].artifacts[0]);
+      expect(packages[0].artifacts[0].builds).toEqual([
+        { format: 'lib', platform: 'browser', support: 'stable' },
+        { format: 'esm', platform: 'browser', support: 'stable' },
+      ]);
+
+      expect(packages[0].artifacts[1].builds).toEqual([
+        { format: 'lib', platform: 'node', support: 'stable' },
+      ]);
     });
   });
 
@@ -459,14 +466,14 @@ describe('Packemon', () => {
           formats: ['lib'],
           inputs: { index: 'src/index.ts' },
           namespace: '',
-          platforms: ['node'],
+          platform: 'node',
           support: 'stable',
         },
         {
           formats: ['lib', 'esm'],
           inputs: { index: 'src/index.ts' },
           namespace: '',
-          platforms: ['browser'],
+          platform: 'browser',
           support: 'current',
         },
       ]);
@@ -477,7 +484,7 @@ describe('Packemon', () => {
           formats: ['lib'],
           inputs: { core: './src/core.ts' },
           namespace: '',
-          platforms: ['node'],
+          platform: 'node',
           support: 'stable',
         },
       ]);
@@ -488,7 +495,7 @@ describe('Packemon', () => {
           formats: ['lib', 'esm', 'umd'],
           inputs: { index: 'src/index.ts' },
           namespace: 'Test',
-          platforms: ['browser'],
+          platform: 'browser',
           support: 'stable',
         },
       ]);

--- a/tests/Packemon.test.ts
+++ b/tests/Packemon.test.ts
@@ -418,6 +418,16 @@ describe('Packemon', () => {
         },
       ]);
     });
+
+    it.only('generates build artifacts for projects with multiple platforms', async () => {
+      packemon = new Packemon(getFixturePath('project-multi-platform'));
+
+      const packages = await packemon.loadConfiguredPackages();
+
+      packemon.generateArtifacts(packages);
+
+      console.log(packages[0].configs, packages[0].artifacts[0]);
+    });
   });
 
   describe('loadConfiguredPackages()', () => {

--- a/tests/__fixtures__/project-multi-platform/package.json
+++ b/tests/__fixtures__/project-multi-platform/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "project-multi-platform",
+  "packemon": {
+    "platform": ["browser", "node"]
+  }
+}

--- a/tests/rollup/config.test.ts
+++ b/tests/rollup/config.test.ts
@@ -188,7 +188,7 @@ describe('getRollupConfig()', () => {
   it('includes analyzer plugin if `analyze` feature flag is on', () => {
     expect(getRollupConfig(artifact, { analyze: 'treemap' }).plugins).toEqual([
       ...sharedPlugins,
-      'visualizer(treemap, stats-e000d9e1.html, project/index)',
+      'visualizer(treemap, stats-project-index.html, project/index)',
     ]);
   });
 

--- a/types/string-hash.d.ts
+++ b/types/string-hash.d.ts
@@ -1,3 +1,0 @@
-declare module 'string-hash' {
-  export default function hash(value: string): number;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6594,11 +6594,6 @@ string-argv@~0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-string-hash@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
-  integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
-
 string-length@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.1.0.tgz#107ef8c23456e187a8abd4a61162ff4ac6e25837"


### PR DESCRIPTION
I've noticed a few edge cases where certain formats weren't being built, or CLI output was missing information. I believe the root is caused by our configs that support multiple platforms, since it requires a bunch of weird resolution logic.

To resolve this, I updated `Package#setConfigs` to create additional configs when platforms is an array. This results in truly unique and deterministic builds.