### PR TITLE
new: Rework automatic entry points and exports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "beemo jest",
     "type": "beemo typescript --noEmit",
     "prerelease": "yarn run clean && yarn run setup && yarn run pack && yarn run ci",
-    "pack": "NODE_ENV=production yarn run packemon pack --addEngines --declaration=api",
+    "pack": "NODE_ENV=production yarn run packemon pack --addEngines --addExports --declaration=api",
     "packemon": "node ./packemon.js"
   },
   "repository": "https://github.com/milesj/packemon.git",
@@ -32,6 +32,21 @@
   "main": "./lib/index.js",
   "types": "./dts/index.d.ts",
   "bin": "./lib/bin.js",
+  "exports": {
+    "./package.json": "./package.json",
+    "./babel": {
+      "node": "./lib/babel.js",
+      "types": "./dts/babel.d.ts"
+    },
+    "./bin": {
+      "node": "./lib/bin.js",
+      "types": "./dts/bin.d.ts"
+    },
+    ".": {
+      "node": "./lib/index.js",
+      "types": "./dts/index.d.ts"
+    }
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=10.3.0",

--- a/src/Artifact.ts
+++ b/src/Artifact.ts
@@ -28,10 +28,6 @@ export default abstract class Artifact<T extends object = {}> {
     return this.state === 'building';
   }
 
-  postBuild(options: BuildOptions): Awaitable {}
-
-  preBuild(options: BuildOptions): Awaitable {}
-
   startup() {}
 
   toString(): string {

--- a/src/BundleArtifact.ts
+++ b/src/BundleArtifact.ts
@@ -1,10 +1,10 @@
 import { rollup, RollupCache } from 'rollup';
-import { isObject, Path, SettingMap, toArray } from '@boost/common';
+import { isObject, Path, toArray } from '@boost/common';
 import { createDebugger, Debugger } from '@boost/debug';
 import Artifact from './Artifact';
 import { DEFAULT_FORMAT, NODE_SUPPORTED_VERSIONS, NPM_SUPPORTED_VERSIONS } from './constants';
 import { getRollupConfig } from './rollup/config';
-import { BuildOptions, BundleBuild, Format, Platform, Support } from './types';
+import { BuildOptions, BundleBuild, Format, PackageExportPaths, Platform, Support } from './types';
 
 export default class BundleArtifact extends Artifact<BundleBuild> {
   cache?: RollupCache;
@@ -129,8 +129,8 @@ export default class BundleArtifact extends Artifact<BundleBuild> {
     };
   }
 
-  getPackageExports(): Record<string, SettingMap | string> {
-    const paths: SettingMap = {};
+  getPackageExports(): PackageExportPaths {
+    const paths: PackageExportPaths = {};
     let libPath = '';
 
     this.builds.forEach(({ format }) => {

--- a/src/TypesArtifact.ts
+++ b/src/TypesArtifact.ts
@@ -76,10 +76,6 @@ export default class TypesArtifact extends Artifact<TypesBuild> {
     }
   }
 
-  postBuild(): void {
-    this.package.packageJson.types = './dts/index.d.ts';
-  }
-
   getLabel(): string {
     return 'types';
   }

--- a/src/TypesArtifact.ts
+++ b/src/TypesArtifact.ts
@@ -5,7 +5,13 @@ import { Path } from '@boost/common';
 import { createDebugger, Debugger } from '@boost/debug';
 import { Extractor, ExtractorConfig } from '@microsoft/api-extractor';
 import Artifact from './Artifact';
-import { APIExtractorStructure, DeclarationType, TSConfigStructure, TypesBuild } from './types';
+import {
+  APIExtractorStructure,
+  DeclarationType,
+  PackageExports,
+  TSConfigStructure,
+  TypesBuild,
+} from './types';
 
 // eslint-disable-next-line
 const extractorConfig = require(path.join(__dirname, '../api-extractor.json')) as {
@@ -80,6 +86,18 @@ export default class TypesArtifact extends Artifact<TypesBuild> {
 
   getBuildTargets(): string[] {
     return ['dts'];
+  }
+
+  getPackageExports(): PackageExports {
+    const exports: PackageExports = {};
+
+    this.builds.forEach(({ outputName }) => {
+      exports[`./${outputName}`] = {
+        types: `./dts/${outputName}.d.ts`,
+      };
+    });
+
+    return exports;
   }
 
   toString() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,25 @@ export interface PackageConfig {
   support: Support;
 }
 
+// PACKAGE EXPORTS
+// https://webpack.js.org/guides/package-exports
+
+export type PackageExportConditions =
+  | 'browser'
+  | 'default'
+  | 'import'
+  | 'module'
+  | 'node'
+  | 'react-native'
+  | 'require'
+  | 'types';
+
+export type PackageExportPaths = {
+  [K in PackageExportConditions]?: PackageExportPaths | string;
+};
+
+export type PackageExports = Record<string, PackageExportPaths | string>;
+
 // BUILD
 
 export type ArtifactState = 'building' | 'failed' | 'passed' | 'pending';

--- a/tests/BundleArtifact.test.ts
+++ b/tests/BundleArtifact.test.ts
@@ -117,203 +117,40 @@ describe('BundleArtifact', () => {
       expect(bundleWriteSpy).toHaveBeenCalledWith({ c: true });
       expect(artifact.builds[2].stats?.size).toBe(4);
     });
-  });
-
-  describe('postBuild()', () => {
-    describe('entry points', () => {
-      it('adds "main" for `lib` format', () => {
-        artifact.platform = 'browser';
-        artifact.builds.push({ format: 'lib', platform: 'browser', support: 'stable' });
-
-        expect(artifact.package.packageJson).toEqual(packageJson);
-
-        artifact.postBuild({});
-
-        expect(artifact.package.packageJson).toEqual({
-          ...packageJson,
-          main: './lib/index.js',
-        });
-      });
-
-      it('adds "main" for `lib` format and shared lib required', () => {
-        artifact.sharedLib = true;
-        artifact.platform = 'browser';
-        artifact.builds.push({ format: 'lib', platform: 'browser', support: 'stable' });
-
-        expect(artifact.package.packageJson).toEqual(packageJson);
-
-        artifact.postBuild({});
-
-        expect(artifact.package.packageJson).toEqual({
-          ...packageJson,
-          main: './lib/browser/index.js',
-        });
-      });
-
-      it('adds "main" for `cjs` format', () => {
-        artifact.builds.push({ format: 'cjs', platform: 'node', support: 'stable' });
-
-        expect(artifact.package.packageJson).toEqual(packageJson);
-
-        artifact.package.packageJson.type = 'commonjs';
-        artifact.postBuild({});
-
-        expect(artifact.package.packageJson).toEqual({
-          ...packageJson,
-          main: './cjs/index.cjs',
-          type: 'commonjs',
-        });
-      });
-
-      it('doesnt add "main" for `cjs` format if no package `type`', () => {
-        artifact.builds.push({ format: 'cjs', platform: 'node', support: 'stable' });
-
-        expect(artifact.package.packageJson).toEqual(packageJson);
-
-        artifact.postBuild({});
-
-        expect(artifact.package.packageJson).toEqual(packageJson);
-      });
-
-      it('adds "main" for `mjs` format', () => {
-        artifact.builds.push({ format: 'mjs', platform: 'node', support: 'stable' });
-
-        expect(artifact.package.packageJson).toEqual(packageJson);
-
-        artifact.package.packageJson.type = 'module';
-        artifact.postBuild({});
-
-        expect(artifact.package.packageJson).toEqual({
-          ...packageJson,
-          main: './mjs/index.mjs',
-          type: 'module',
-        });
-      });
-
-      it('doesnt add  "main" for `mjs` format if no package `type`', () => {
-        artifact.builds.push({ format: 'mjs', platform: 'node', support: 'stable' });
-
-        expect(artifact.package.packageJson).toEqual(packageJson);
-
-        artifact.postBuild({});
-
-        expect(artifact.package.packageJson).toEqual(packageJson);
-      });
-
-      it('adds "module" for `esm` format', () => {
-        artifact.builds.push({ format: 'esm', platform: 'browser', support: 'stable' });
-
-        expect(artifact.package.packageJson).toEqual(packageJson);
-
-        artifact.postBuild({});
-
-        expect(artifact.package.packageJson).toEqual({
-          ...packageJson,
-          module: './esm/index.js',
-        });
-      });
-
-      describe('binary files', () => {
-        beforeEach(() => {
-          artifact.outputName = 'bin';
-        });
-
-        it('adds "bin" for `lib` format', () => {
-          artifact.builds.push({ format: 'lib', platform: 'node', support: 'stable' });
-
-          artifact.postBuild({});
-
-          expect(artifact.package.packageJson).toEqual({
-            ...packageJson,
-            bin: './lib/bin.js',
-          });
-        });
-
-        it('adds "bin" for `lib` format when shared lib required', () => {
-          artifact.sharedLib = true;
-          artifact.builds.push({ format: 'lib', platform: 'node', support: 'stable' });
-
-          artifact.postBuild({});
-
-          expect(artifact.package.packageJson).toEqual({
-            ...packageJson,
-            bin: './lib/node/bin.js',
-          });
-        });
-
-        it('adds "bin" for `cjs` format', () => {
-          artifact.builds.push({ format: 'cjs', platform: 'node', support: 'stable' });
-
-          artifact.package.packageJson.type = 'commonjs';
-          artifact.postBuild({});
-
-          expect(artifact.package.packageJson).toEqual({
-            ...packageJson,
-            bin: './cjs/bin.cjs',
-            type: 'commonjs',
-          });
-        });
-
-        it('adds "bin" for `mjs` format', () => {
-          artifact.builds.push({ format: 'mjs', platform: 'node', support: 'stable' });
-
-          artifact.package.packageJson.type = 'module';
-          artifact.postBuild({});
-
-          expect(artifact.package.packageJson).toEqual({
-            ...packageJson,
-            bin: './mjs/bin.mjs',
-            type: 'module',
-          });
-        });
-
-        it('doesnt set "bin" if already defined as an object', () => {
-          artifact.builds.push({ format: 'lib', platform: 'node', support: 'stable' });
-          artifact.package.packageJson.bin = { example: './bin.js' };
-
-          artifact.postBuild({});
-
-          expect(artifact.package.packageJson).toEqual({
-            ...packageJson,
-            bin: { example: './bin.js' },
-          });
-        });
-      });
-    });
 
     describe('engines', () => {
-      it('does nothing if builds is not `node`', () => {
+      it('does nothing if builds is not `node`', async () => {
         artifact.platform = 'browser';
         artifact.builds.push({ format: 'lib', platform: 'browser', support: 'stable' });
 
         expect(artifact.package.packageJson.engines).toBeUndefined();
 
-        artifact.postBuild({ addEngines: true });
+        await artifact.build({ addEngines: true });
 
         expect(artifact.package.packageJson.engines).toBeUndefined();
       });
 
-      it('does nothing if `addEngines` is false', () => {
+      it('does nothing if `addEngines` is false', async () => {
         artifact.builds.push({ format: 'lib', platform: 'node', support: 'stable' });
 
         expect(artifact.package.packageJson.engines).toBeUndefined();
 
-        artifact.postBuild({ addEngines: false });
+        await artifact.build({ addEngines: false });
 
         expect(artifact.package.packageJson.engines).toBeUndefined();
       });
 
-      it('adds npm and node engines for `node` build', () => {
+      it('adds npm and node engines for `node` build', async () => {
         artifact.builds.push({ format: 'lib', platform: 'node', support: 'stable' });
 
         expect(artifact.package.packageJson.engines).toBeUndefined();
 
-        artifact.postBuild({ addEngines: true });
+        await artifact.build({ addEngines: true });
 
         expect(artifact.package.packageJson.engines).toEqual({ node: '>=10.3.0', npm: '>=6.1.0' });
       });
 
-      it('merges with existing engines', () => {
+      it('merges with existing engines', async () => {
         artifact.builds.push({ format: 'lib', platform: 'node', support: 'stable' });
 
         artifact.package.packageJson.engines = {
@@ -322,7 +159,7 @@ describe('BundleArtifact', () => {
 
         expect(artifact.package.packageJson.engines).toEqual({ packemon: '*' });
 
-        artifact.postBuild({ addEngines: true });
+        await artifact.build({ addEngines: true });
 
         expect(artifact.package.packageJson.engines).toEqual({
           packemon: '*',

--- a/tests/TypesArtifact.test.ts
+++ b/tests/TypesArtifact.test.ts
@@ -235,25 +235,6 @@ describe('TypesArtifact', () => {
     });
   });
 
-  describe('postBuild()', () => {
-    it('sets `types` field in `package.json`', () => {
-      expect(artifact.package.packageJson).toEqual({
-        name: 'project',
-        version: '0.0.0',
-        packemon: {},
-      });
-
-      artifact.postBuild();
-
-      expect(artifact.package.packageJson).toEqual({
-        name: 'project',
-        version: '0.0.0',
-        packemon: {},
-        types: './dts/index.d.ts',
-      });
-    });
-  });
-
   describe('getPackageExports()', () => {
     it('adds exports based on input file and output name builds', () => {
       expect(artifact.getPackageExports()).toEqual({

--- a/tests/TypesArtifact.test.ts
+++ b/tests/TypesArtifact.test.ts
@@ -253,4 +253,17 @@ describe('TypesArtifact', () => {
       });
     });
   });
+
+  describe('getPackageExports()', () => {
+    it('adds exports based on input file and output name builds', () => {
+      expect(artifact.getPackageExports()).toEqual({
+        './index': {
+          types: './dts/index.d.ts',
+        },
+        './test': {
+          types: './dts/test.d.ts',
+        },
+      });
+    });
+  });
 });

--- a/website/docs/setup.mdx
+++ b/website/docs/setup.mdx
@@ -82,9 +82,9 @@ This would look something like the following.
 
 ### Transforming generators
 
-If you are using generators and are targeting the `browser` platform with either the `legacy` or
-`stable` supported version, you will need to include the `@babel/runtime` dependency in your
-project. This is because generators are compiled to `regenerator-runtime`
+If you are using generators and are targeting the `browser` platform with a non-`experimental`
+supported version, you will need to include the `@babel/runtime` dependency in your project. This is
+because generators are compiled to `regenerator-runtime`
 ([more info](https://babeljs.io/docs/en/babel-plugin-transform-runtime#regenerator-aliasing)).
 
 <Tabs


### PR DESCRIPTION
Because of this PR https://github.com/milesj/packemon/pull/25, automatic entry point's became harder to determine. To resolve this, I moved this logic up to the parent `Package` class, since it has more context.

Also updated `exports` to align more with Webpack/Rollup: https://webpack.js.org/guides/package-exports