### PR TITLE
new: Support `browser` field when applicable.

### DIFF
--- a/tests/Package.test.ts
+++ b/tests/Package.test.ts
@@ -324,6 +324,34 @@ describe('Package', () => {
         });
       });
 
+      describe('browser', () => {
+        it('adds "browser" when browser and node are sharing a lib', async () => {
+          const node = createBundleArtifact([
+            { format: 'lib', platform: 'node', support: 'stable' },
+          ]);
+          node.platform = 'node';
+          node.sharedLib = true;
+
+          const browser = createBundleArtifact([
+            { format: 'lib', platform: 'browser', support: 'stable' },
+          ]);
+          browser.platform = 'browser';
+          browser.sharedLib = true;
+
+          pkg.addArtifact(node);
+          pkg.addArtifact(browser);
+
+          await pkg.build({});
+
+          expect(pkg.packageJson).toEqual(
+            expect.objectContaining({
+              main: './lib/node/index.js',
+              browser: './lib/browser/index.js',
+            }),
+          );
+        });
+      });
+
       describe('types', () => {
         it('adds "types" when a types artifact exists', async () => {
           pkg.addArtifact(createTypesArtifact([]));

--- a/tests/Package.test.ts
+++ b/tests/Package.test.ts
@@ -325,7 +325,7 @@ describe('Package', () => {
       });
 
       describe('browser', () => {
-        it('adds "browser" when browser and node are sharing a lib', async () => {
+        beforeEach(() => {
           const node = createBundleArtifact([
             { format: 'lib', platform: 'node', support: 'stable' },
           ]);
@@ -340,13 +340,29 @@ describe('Package', () => {
 
           pkg.addArtifact(node);
           pkg.addArtifact(browser);
+        });
 
+        it('adds "browser" when browser and node are sharing a lib', async () => {
           await pkg.build({});
 
           expect(pkg.packageJson).toEqual(
             expect.objectContaining({
               main: './lib/node/index.js',
               browser: './lib/browser/index.js',
+            }),
+          );
+        });
+
+        it('doesnt override "browser" field if its an object', async () => {
+          // @ts-expect-error Types are wrong
+          pkg.packageJson.browser = { module: 'foo' };
+
+          await pkg.build({});
+
+          expect(pkg.packageJson).toEqual(
+            expect.objectContaining({
+              main: './lib/node/index.js',
+              browser: { module: 'foo' },
             }),
           );
         });


### PR DESCRIPTION
Prefer `main` when only building for the browser, but if we support multiple platforms we should also set `browser`.