### PR TITLE
new: Update experimental target to Node v16.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [10, 12, 14, 15]
+        node-version: [10, 12, 14, 16]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,7 +35,7 @@ export const NODE_SUPPORTED_VERSIONS: { [K in Support]: string } = {
   legacy: '8.10.0',
   stable: '10.3.0', // Requires NPM v6
   current: '12.0.0',
-  experimental: '15.0.0',
+  experimental: '16.0.0',
 };
 
 export const NPM_SUPPORTED_VERSIONS: { [K in Support]: string[] | string } = {

--- a/tests/babel/__snapshots__/config.test.ts.snap
+++ b/tests/babel/__snapshots__/config.test.ts.snap
@@ -620,7 +620,7 @@ Array [
     "shippedProposals": true,
     "spec": true,
     "targets": Object {
-      "node": "15.0.0",
+      "node": "16.0.0",
     },
     "useBuiltIns": false,
   },
@@ -704,7 +704,7 @@ Array [
     "shippedProposals": true,
     "spec": true,
     "targets": Object {
-      "node": "15.0.0",
+      "node": "16.0.0",
     },
     "useBuiltIns": false,
   },
@@ -788,7 +788,7 @@ Array [
     "shippedProposals": true,
     "spec": true,
     "targets": Object {
-      "node": "15.0.0",
+      "node": "16.0.0",
     },
     "useBuiltIns": false,
   },
@@ -1051,7 +1051,7 @@ Object {
         "shippedProposals": true,
         "spec": true,
         "targets": Object {
-          "node": "15.0.0",
+          "node": "16.0.0",
         },
         "useBuiltIns": false,
       },

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -92,7 +92,7 @@ The supported environments above map to the following platform targets.
 | ---------- | --------- | --------- | ------------ | ---------------------- |
 | Browser    | >= IE 10  | >= IE 11  | > 0.5% usage | last 2 chrome versions |
 | Native     | >= iOS 8  | >= iOS 10 | >= iOS 12    | >= iOS 14              |
-| Node       | >= 8.10.0 | >= 10.3.0 | >= 12.0.0    | >= 15.0.0              |
+| Node       | >= 8.10.0 | >= 10.3.0 | >= 12.0.0    | >= 16.0.0              |
 | Node (NPM) | >= 5.6.0  | >= 6.1.0  | >= 6.9.0     | >= 7.0.0               |
 
 ## Formats


### PR DESCRIPTION
Also enable in CI.