### PR TITLE
new: Switch to Babel for non-bundle builds.

### DIFF
--- a/src/BundleArtifact.ts
+++ b/src/BundleArtifact.ts
@@ -74,7 +74,7 @@ export class BundleArtifact extends Artifact<BundleBuild> {
   }
 
   async buildWithBabel(features: FeatureFlags): Promise<void> {
-    this.debug('Building bundle artifact with Bable');
+    this.debug('Building bundle artifact with Babel');
 
     const inputConfig = getBabelInputConfig(this, features);
     const packageRoot = this.package.path;
@@ -123,10 +123,9 @@ export class BundleArtifact extends Artifact<BundleBuild> {
               result.code += `\n//# sourceMappingURL=${path.basename(outFile)}.map`;
             }
 
-            if (result.code) {
-              combinedCode += result.code;
-              await fs.writeFile(outFile, result.code, 'utf8');
-            }
+            combinedCode += result.code;
+
+            await fs.writeFile(outFile, result.code, 'utf8');
           }),
         );
 

--- a/src/Packemon.ts
+++ b/src/Packemon.ts
@@ -235,7 +235,6 @@ export class Packemon {
         Object.entries(config.inputs).forEach(([outputName, inputFile]) => {
           // Pass platform and support here for convenience
           let builds = config.formats.map((format) => ({
-            bundle: config.bundle,
             format,
             platform: config.platform,
             support: config.support,
@@ -258,6 +257,7 @@ export class Packemon {
           }
 
           const artifact = new BundleArtifact(pkg, builds);
+          artifact.bundle = config.bundle;
           artifact.configGroup = index;
           artifact.inputFile = inputFile;
           artifact.outputName = outputName;

--- a/src/babel/config.ts
+++ b/src/babel/config.ts
@@ -134,7 +134,12 @@ export function getBabelInputConfig(
     ]);
   }
 
-  return getSharedConfig(plugins, presets, features);
+  const config = getSharedConfig(plugins, presets, features);
+
+  // Extract maps from the original source
+  config.sourceMaps = true;
+
+  return config;
 }
 
 // The output config does all the transformation and downleveling through the preset-env.

--- a/src/babel/formatSourcemap.ts
+++ b/src/babel/formatSourcemap.ts
@@ -14,7 +14,7 @@ export function formatSourcemap(
 
   // Rollup sources are relative to the actual source file, while Babel
   // is just the name of the source file. Match Rollup's implementation.
-  if (data.sources.length > 0) {
+  if (data.sources?.length > 0) {
     data.sources = [path.relative(path.dirname(outFile), inFile)];
   }
 

--- a/src/babel/formatSourcemap.ts
+++ b/src/babel/formatSourcemap.ts
@@ -1,0 +1,22 @@
+import path from 'path';
+import { BabelFileResult } from '@babel/core';
+
+export function formatSourcemap(
+  map: NonNullable<BabelFileResult['map']>,
+  inFile: string,
+  outFile: string,
+) {
+  const data = {
+    ...map,
+    file: path.basename(outFile),
+    sourcesContent: null,
+  };
+
+  // Rollup sources are relative to the actual source file, while Babel
+  // is just the name of the source file. Match Rollup's implementation.
+  if (data.sources.length > 0) {
+    data.sources = [path.relative(path.dirname(outFile), inFile)];
+  }
+
+  return JSON.stringify(data);
+}

--- a/src/helpers/getOutputBanner.ts
+++ b/src/helpers/getOutputBanner.ts
@@ -1,0 +1,8 @@
+import { BundleBuild } from '../types';
+
+export function getOutputBanner({ platform, support, format }: BundleBuild): string {
+  return [
+    '// Generated with Packemon: https://packemon.dev\n',
+    `// Platform: ${platform}, Support: ${support}, Format: ${format}\n\n`,
+  ].join('');
+}

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -9,6 +9,7 @@ import resolve from '@rollup/plugin-node-resolve';
 import { getBabelInputConfig, getBabelOutputConfig } from '../babel/config';
 import type { BundleArtifact } from '../BundleArtifact';
 import { EXCLUDE, EXTENSIONS } from '../constants';
+import { getOutputBanner } from '../helpers/getOutputBanner';
 import { BundleBuild, FeatureFlags, Format } from '../types';
 
 const sharedPlugins = [
@@ -90,7 +91,7 @@ export function getRollupOutputConfig(
   features: FeatureFlags,
   build: BundleBuild,
 ): OutputOptions {
-  const { format, platform, support } = build;
+  const { format, support } = build;
   const name = artifact.outputName;
   const { ext, folder } = artifact.getOutputMetadata(format);
   const isTest = process.env.NODE_ENV === 'test';
@@ -130,11 +131,7 @@ export function getRollupOutputConfig(
 
   // Automatically prepend a shebang for binaries
   output.banner = artifact.outputName === 'bin' ? '#!/usr/bin/env node\n\n' : '';
-
-  output.banner += [
-    '// Generated with Packemon: https://packemon.dev\n',
-    `// Platform: ${platform}, Support: ${support}, Format: ${format}\n\n`,
-  ].join('');
+  output.banner += getOutputBanner(build);
 
   return output;
 }

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -90,11 +90,10 @@ export function getRollupOutputConfig(
   features: FeatureFlags,
   build: BundleBuild,
 ): OutputOptions {
-  const { bundle = true, format, platform, support } = build;
+  const { format, platform, support } = build;
   const name = artifact.outputName;
   const { ext, folder } = artifact.getOutputMetadata(format);
   const isTest = process.env.NODE_ENV === 'test';
-  const preserve = !bundle;
 
   const output: OutputOptions = {
     dir: artifact.package.path.append(folder).path(),
@@ -104,9 +103,8 @@ export function getRollupOutputConfig(
     paths: getRollupPaths(artifact, ext),
     // Use our extension for file names
     assetFileNames: '../assets/[name]-[hash][extname]',
-    chunkFileNames: preserve && !isTest ? `[name]-[hash].${ext}` : `${name}-[hash].${ext}`,
-    entryFileNames: preserve && !isTest ? `[name].${ext}` : `${name}.${ext}`,
-    preserveModules: preserve,
+    chunkFileNames: !isTest ? `[name]-[hash].${ext}` : `${name}-[hash].${ext}`,
+    entryFileNames: !isTest ? `[name].${ext}` : `${name}.${ext}`,
     // Use const when not supporting new targets
     preferConst: support === 'current' || support === 'experimental',
     // Output specific plugins
@@ -176,8 +174,7 @@ export function getRollupConfig(artifact: BundleArtifact, features: FeatureFlags
       }),
     ],
     // Treeshake for smaller builds
-    // Only apply when not bundling so we dont lose information
-    treeshake: artifact.builds.every((build) => !build.bundle),
+    treeshake: true,
   };
 
   // Polyfill node modules when platform is not node

--- a/src/rollup/config.ts
+++ b/src/rollup/config.ts
@@ -169,8 +169,6 @@ export function getRollupConfig(artifact: BundleArtifact, features: FeatureFlags
         exclude: process.env.NODE_ENV === 'test' ? [] : EXCLUDE,
         extensions: EXTENSIONS,
         filename: artifact.package.path.path(),
-        // Extract maps from the original source
-        sourceMaps: true,
       }),
     ],
     // Treeshake for smaller builds

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -58,7 +58,11 @@ const support = string<Support>(DEFAULT_SUPPORT).oneOf(SUPPORTS);
 // BLUEPRINTS
 
 export const packemonBlueprint: Blueprint<PackemonPackageConfig> = {
-  bundle: bool(true),
+  bundle: bool(true).custom<PackemonPackageConfig>((bundle, shape) => {
+    if (!bundle && toArray(shape.struct.format).includes('umd')) {
+      throw new Error('UMD format cannot be used unless `bundle` is true.');
+    }
+  }),
   format: union([array(format), format], []),
   inputs: object(string(), { index: DEFAULT_INPUT }).custom((obj) => {
     Object.keys(obj).forEach((key) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,7 +124,6 @@ export interface BuildResult {
 }
 
 export interface BundleBuild {
-  bundle?: boolean;
   format: Format;
   platform: Platform;
   support: Support;

--- a/tests/Packemon.test.ts
+++ b/tests/Packemon.test.ts
@@ -330,30 +330,30 @@ describe('Packemon', () => {
       expect((packages[0].artifacts[0] as BundleArtifact).outputName).toBe('index');
       expect((packages[0].artifacts[0] as BundleArtifact).inputFile).toBe('src/index.ts');
       expect(packages[0].artifacts[0].builds).toEqual([
-        { bundle: false, format: 'lib', platform: 'node', support: 'stable' },
+        { format: 'lib', platform: 'node', support: 'stable' },
       ]);
 
       expect((packages[0].artifacts[1] as BundleArtifact).outputName).toBe('index');
       expect((packages[0].artifacts[1] as BundleArtifact).inputFile).toBe('src/index.ts');
       expect(packages[0].artifacts[1].builds).toEqual([
-        { bundle: true, format: 'lib', platform: 'browser', support: 'current' },
-        { bundle: true, format: 'esm', platform: 'browser', support: 'current' },
+        { format: 'lib', platform: 'browser', support: 'current' },
+        { format: 'esm', platform: 'browser', support: 'current' },
       ]);
 
       expect(packages[1].artifacts).toHaveLength(1);
       expect((packages[1].artifacts[0] as BundleArtifact).outputName).toBe('core');
       expect((packages[1].artifacts[0] as BundleArtifact).inputFile).toBe('./src/core.ts');
       expect(packages[1].artifacts[0].builds).toEqual([
-        { bundle: false, format: 'lib', platform: 'node', support: 'stable' },
+        { format: 'lib', platform: 'node', support: 'stable' },
       ]);
 
       expect(packages[2].artifacts).toHaveLength(1);
       expect((packages[2].artifacts[0] as BundleArtifact).outputName).toBe('index');
       expect((packages[2].artifacts[0] as BundleArtifact).inputFile).toBe('src/index.ts');
       expect(packages[2].artifacts[0].builds).toEqual([
-        { bundle: true, format: 'lib', platform: 'browser', support: 'stable' },
-        { bundle: true, format: 'esm', platform: 'browser', support: 'stable' },
-        { bundle: true, format: 'umd', platform: 'browser', support: 'stable' },
+        { format: 'lib', platform: 'browser', support: 'stable' },
+        { format: 'esm', platform: 'browser', support: 'stable' },
+        { format: 'umd', platform: 'browser', support: 'stable' },
       ]);
     });
 
@@ -431,12 +431,12 @@ describe('Packemon', () => {
       packemon.generateArtifacts(packages);
 
       expect(packages[0].artifacts[0].builds).toEqual([
-        { bundle: true, format: 'lib', platform: 'browser', support: 'stable' },
-        { bundle: true, format: 'esm', platform: 'browser', support: 'stable' },
+        { format: 'lib', platform: 'browser', support: 'stable' },
+        { format: 'esm', platform: 'browser', support: 'stable' },
       ]);
 
       expect(packages[0].artifacts[1].builds).toEqual([
-        { bundle: false, format: 'lib', platform: 'node', support: 'stable' },
+        { format: 'lib', platform: 'node', support: 'stable' },
       ]);
     });
 
@@ -450,7 +450,7 @@ describe('Packemon', () => {
       });
 
       expect(packages[0].artifacts[0].builds).toEqual([
-        { bundle: true, format: 'esm', platform: 'browser', support: 'stable' },
+        { format: 'esm', platform: 'browser', support: 'stable' },
       ]);
 
       expect(packages[0].artifacts[1]).toBeUndefined();
@@ -466,7 +466,7 @@ describe('Packemon', () => {
       });
 
       expect(packages[0].artifacts[0].builds).toEqual([
-        { bundle: false, format: 'lib', platform: 'node', support: 'stable' },
+        { format: 'lib', platform: 'node', support: 'stable' },
       ]);
 
       expect(packages[0].artifacts[1]).toBeUndefined();

--- a/tests/babel/__snapshots__/config.test.ts.snap
+++ b/tests/babel/__snapshots__/config.test.ts.snap
@@ -155,6 +155,7 @@ Object {
   },
   "plugins": Array [],
   "presets": Array [],
+  "sourceMaps": true,
 }
 `;
 
@@ -184,6 +185,7 @@ Object {
   },
   "plugins": Array [],
   "presets": Array [],
+  "sourceMaps": true,
 }
 `;
 
@@ -240,6 +242,7 @@ Object {
       },
     ],
   ],
+  "sourceMaps": true,
 }
 `;
 
@@ -301,6 +304,7 @@ Object {
       },
     ],
   ],
+  "sourceMaps": true,
 }
 `;
 

--- a/tests/examples/__snapshots__/jsonImports.test.ts.snap
+++ b/tests/examples/__snapshots__/jsonImports.test.ts.snap
@@ -10,9 +10,14 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
-const data = require('./index-node-current-cjs2.cjs'); // @ts-expect-error resolveJsonModule is not on
-
+const data = {
+  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
+  number: 123,
+  string: \\"abc\\",
+  object: {
+    foo: true
+  }
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 exports.keys = keys;
@@ -23,27 +28,6 @@ exports.keys = keys;
 
 exports[`JSON imports transforms example test case 2`] = `
 Array [
-  "/cjs/index-node-current-cjs2.cjs",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: current, Format: cjs
-'use strict';
-
-const data = {
-  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
-  number: 123,
-  string: \\"abc\\",
-  object: {
-    foo: true
-  }
-};
-module.exports = data;
-//# sourceMappingURL=index-node-current-cjs2.cjs.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 3`] = `
-Array [
   "/cjs/index-node-experimental-cjs.cjs",
   "// Generated with Packemon: https://packemon.dev
 // Platform: node, Support: experimental, Format: cjs
@@ -52,9 +36,14 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
-const data = require('./index-node-experimental-cjs2.cjs'); // @ts-expect-error resolveJsonModule is not on
-
+const data = {
+  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
+  number: 123,
+  string: \\"abc\\",
+  object: {
+    foo: true
+  }
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 exports.keys = keys;
@@ -63,28 +52,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 4`] = `
-Array [
-  "/cjs/index-node-experimental-cjs2.cjs",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: experimental, Format: cjs
-'use strict';
-
-const data = {
-  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
-  number: 123,
-  string: \\"abc\\",
-  object: {
-    foo: true
-  }
-};
-module.exports = data;
-//# sourceMappingURL=index-node-experimental-cjs2.cjs.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 5`] = `
+exports[`JSON imports transforms example test case 3`] = `
 Array [
   "/cjs/index-node-legacy-cjs.cjs",
   "// Generated with Packemon: https://packemon.dev
@@ -94,9 +62,14 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
-var data = require('./index-node-legacy-cjs2.cjs'); // @ts-expect-error resolveJsonModule is not on
-
+var data = {
+  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
+  number: 123,
+  string: \\"abc\\",
+  object: {
+    foo: true
+  }
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 exports.keys = keys;
@@ -105,28 +78,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 6`] = `
-Array [
-  "/cjs/index-node-legacy-cjs2.cjs",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: legacy, Format: cjs
-'use strict';
-
-var data = {
-  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
-  number: 123,
-  string: \\"abc\\",
-  object: {
-    foo: true
-  }
-};
-module.exports = data;
-//# sourceMappingURL=index-node-legacy-cjs2.cjs.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 7`] = `
+exports[`JSON imports transforms example test case 4`] = `
 Array [
   "/cjs/index-node-stable-cjs.cjs",
   "// Generated with Packemon: https://packemon.dev
@@ -136,9 +88,14 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
-var data = require('./index-node-stable-cjs2.cjs'); // @ts-expect-error resolveJsonModule is not on
-
+var data = {
+  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
+  number: 123,
+  string: \\"abc\\",
+  object: {
+    foo: true
+  }
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 exports.keys = keys;
@@ -147,28 +104,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 8`] = `
-Array [
-  "/cjs/index-node-stable-cjs2.cjs",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: stable, Format: cjs
-'use strict';
-
-var data = {
-  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
-  number: 123,
-  string: \\"abc\\",
-  object: {
-    foo: true
-  }
-};
-module.exports = data;
-//# sourceMappingURL=index-node-stable-cjs2.cjs.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 9`] = `
+exports[`JSON imports transforms example test case 5`] = `
 Array [
   "/esm/index-browser-current-esm.js",
   "// Generated with Packemon: https://packemon.dev
@@ -189,7 +125,7 @@ export { keys };
 ]
 `;
 
-exports[`JSON imports transforms example test case 10`] = `
+exports[`JSON imports transforms example test case 6`] = `
 Array [
   "/esm/index-browser-experimental-esm.js",
   "// Generated with Packemon: https://packemon.dev
@@ -210,7 +146,7 @@ export { keys };
 ]
 `;
 
-exports[`JSON imports transforms example test case 11`] = `
+exports[`JSON imports transforms example test case 7`] = `
 Array [
   "/esm/index-browser-legacy-esm.js",
   "// Generated with Packemon: https://packemon.dev
@@ -231,7 +167,7 @@ export { keys };
 ]
 `;
 
-exports[`JSON imports transforms example test case 12`] = `
+exports[`JSON imports transforms example test case 8`] = `
 Array [
   "/esm/index-browser-stable-esm.js",
   "// Generated with Packemon: https://packemon.dev
@@ -252,7 +188,7 @@ export { keys };
 ]
 `;
 
-exports[`JSON imports transforms example test case 13`] = `
+exports[`JSON imports transforms example test case 9`] = `
 Array [
   "/lib/index-browser-current-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -278,7 +214,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 14`] = `
+exports[`JSON imports transforms example test case 10`] = `
 Array [
   "/lib/index-browser-experimental-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -304,7 +240,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 15`] = `
+exports[`JSON imports transforms example test case 11`] = `
 Array [
   "/lib/index-browser-legacy-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -330,7 +266,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 16`] = `
+exports[`JSON imports transforms example test case 12`] = `
 Array [
   "/lib/index-browser-stable-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -356,7 +292,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 17`] = `
+exports[`JSON imports transforms example test case 13`] = `
 Array [
   "/lib/index-native-current-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -382,7 +318,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 18`] = `
+exports[`JSON imports transforms example test case 14`] = `
 Array [
   "/lib/index-native-experimental-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -408,7 +344,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 19`] = `
+exports[`JSON imports transforms example test case 15`] = `
 Array [
   "/lib/index-native-legacy-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -434,7 +370,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 20`] = `
+exports[`JSON imports transforms example test case 16`] = `
 Array [
   "/lib/index-native-stable-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -460,7 +396,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 21`] = `
+exports[`JSON imports transforms example test case 17`] = `
 Array [
   "/lib/index-node-current-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -470,9 +406,14 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
-const data = require('./index-node-current-lib2.js'); // @ts-expect-error resolveJsonModule is not on
-
+const data = {
+  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
+  number: 123,
+  string: \\"abc\\",
+  object: {
+    foo: true
+  }
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 exports.keys = keys;
@@ -481,28 +422,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 22`] = `
-Array [
-  "/lib/index-node-current-lib2.js",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: current, Format: lib
-'use strict';
-
-const data = {
-  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
-  number: 123,
-  string: \\"abc\\",
-  object: {
-    foo: true
-  }
-};
-module.exports = data;
-//# sourceMappingURL=index-node-current-lib2.js.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 23`] = `
+exports[`JSON imports transforms example test case 18`] = `
 Array [
   "/lib/index-node-experimental-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -512,9 +432,14 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
-const data = require('./index-node-experimental-lib2.js'); // @ts-expect-error resolveJsonModule is not on
-
+const data = {
+  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
+  number: 123,
+  string: \\"abc\\",
+  object: {
+    foo: true
+  }
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 exports.keys = keys;
@@ -523,28 +448,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 24`] = `
-Array [
-  "/lib/index-node-experimental-lib2.js",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: experimental, Format: lib
-'use strict';
-
-const data = {
-  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
-  number: 123,
-  string: \\"abc\\",
-  object: {
-    foo: true
-  }
-};
-module.exports = data;
-//# sourceMappingURL=index-node-experimental-lib2.js.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 25`] = `
+exports[`JSON imports transforms example test case 19`] = `
 Array [
   "/lib/index-node-legacy-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -554,9 +458,14 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
-var data = require('./index-node-legacy-lib2.js'); // @ts-expect-error resolveJsonModule is not on
-
+var data = {
+  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
+  number: 123,
+  string: \\"abc\\",
+  object: {
+    foo: true
+  }
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 exports.keys = keys;
@@ -565,28 +474,7 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 26`] = `
-Array [
-  "/lib/index-node-legacy-lib2.js",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: legacy, Format: lib
-'use strict';
-
-var data = {
-  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
-  number: 123,
-  string: \\"abc\\",
-  object: {
-    foo: true
-  }
-};
-module.exports = data;
-//# sourceMappingURL=index-node-legacy-lib2.js.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 27`] = `
+exports[`JSON imports transforms example test case 20`] = `
 Array [
   "/lib/index-node-stable-lib.js",
   "// Generated with Packemon: https://packemon.dev
@@ -596,9 +484,14 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-
-var data = require('./index-node-stable-lib2.js'); // @ts-expect-error resolveJsonModule is not on
-
+var data = {
+  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
+  number: 123,
+  string: \\"abc\\",
+  object: {
+    foo: true
+  }
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 exports.keys = keys;
@@ -607,33 +500,19 @@ exports.keys = keys;
 ]
 `;
 
-exports[`JSON imports transforms example test case 28`] = `
+exports[`JSON imports transforms example test case 21`] = `
 Array [
-  "/lib/index-node-stable-lib2.js",
+  "/mjs/index-node-current-mjs.mjs",
   "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: stable, Format: lib
-'use strict';
-
-var data = {
+// Platform: node, Support: current, Format: mjs
+const data = {
   list: [\\"foo\\", \\"bar\\", \\"baz\\"],
   number: 123,
   string: \\"abc\\",
   object: {
     foo: true
   }
-};
-module.exports = data;
-//# sourceMappingURL=index-node-stable-lib2.js.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 29`] = `
-Array [
-  "/mjs/index-node-current-mjs.mjs",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: current, Format: mjs
-import data from './index-node-current-mjs2.mjs'; // @ts-expect-error resolveJsonModule is not on
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 export { keys };
@@ -642,11 +521,11 @@ export { keys };
 ]
 `;
 
-exports[`JSON imports transforms example test case 30`] = `
+exports[`JSON imports transforms example test case 22`] = `
 Array [
-  "/mjs/index-node-current-mjs2.mjs",
+  "/mjs/index-node-experimental-mjs.mjs",
   "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: current, Format: mjs
+// Platform: node, Support: experimental, Format: mjs
 const data = {
   list: [\\"foo\\", \\"bar\\", \\"baz\\"],
   number: 123,
@@ -654,19 +533,7 @@ const data = {
   object: {
     foo: true
   }
-};
-export default data;
-//# sourceMappingURL=index-node-current-mjs2.mjs.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 31`] = `
-Array [
-  "/mjs/index-node-experimental-mjs.mjs",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: experimental, Format: mjs
-import data from './index-node-experimental-mjs2.mjs'; // @ts-expect-error resolveJsonModule is not on
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 export { keys };
@@ -675,31 +542,19 @@ export { keys };
 ]
 `;
 
-exports[`JSON imports transforms example test case 32`] = `
+exports[`JSON imports transforms example test case 23`] = `
 Array [
-  "/mjs/index-node-experimental-mjs2.mjs",
+  "/mjs/index-node-legacy-mjs.mjs",
   "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: experimental, Format: mjs
-const data = {
+// Platform: node, Support: legacy, Format: mjs
+var data = {
   list: [\\"foo\\", \\"bar\\", \\"baz\\"],
   number: 123,
   string: \\"abc\\",
   object: {
     foo: true
   }
-};
-export default data;
-//# sourceMappingURL=index-node-experimental-mjs2.mjs.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 33`] = `
-Array [
-  "/mjs/index-node-legacy-mjs.mjs",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: legacy, Format: mjs
-import data from './index-node-legacy-mjs2.mjs'; // @ts-expect-error resolveJsonModule is not on
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 export { keys };
@@ -708,11 +563,11 @@ export { keys };
 ]
 `;
 
-exports[`JSON imports transforms example test case 34`] = `
+exports[`JSON imports transforms example test case 24`] = `
 Array [
-  "/mjs/index-node-legacy-mjs2.mjs",
+  "/mjs/index-node-stable-mjs.mjs",
   "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: legacy, Format: mjs
+// Platform: node, Support: stable, Format: mjs
 var data = {
   list: [\\"foo\\", \\"bar\\", \\"baz\\"],
   number: 123,
@@ -720,19 +575,7 @@ var data = {
   object: {
     foo: true
   }
-};
-export default data;
-//# sourceMappingURL=index-node-legacy-mjs2.mjs.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 35`] = `
-Array [
-  "/mjs/index-node-stable-mjs.mjs",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: stable, Format: mjs
-import data from './index-node-stable-mjs2.mjs'; // @ts-expect-error resolveJsonModule is not on
+}; // @ts-expect-error resolveJsonModule is not on
 
 const keys = Object.keys(data);
 export { keys };
@@ -741,26 +584,7 @@ export { keys };
 ]
 `;
 
-exports[`JSON imports transforms example test case 36`] = `
-Array [
-  "/mjs/index-node-stable-mjs2.mjs",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: node, Support: stable, Format: mjs
-var data = {
-  list: [\\"foo\\", \\"bar\\", \\"baz\\"],
-  number: 123,
-  string: \\"abc\\",
-  object: {
-    foo: true
-  }
-};
-export default data;
-//# sourceMappingURL=index-node-stable-mjs2.mjs.map
-",
-]
-`;
-
-exports[`JSON imports transforms example test case 37`] = `
+exports[`JSON imports transforms example test case 25`] = `
 Array [
   "/package.json",
   Object {
@@ -777,7 +601,7 @@ Array [
 ]
 `;
 
-exports[`JSON imports transforms example test case 38`] = `
+exports[`JSON imports transforms example test case 26`] = `
 Array [
   "/umd/index-browser-current-umd.js",
   "(function (global, factory) {
@@ -818,7 +642,7 @@ Array [
 ]
 `;
 
-exports[`JSON imports transforms example test case 39`] = `
+exports[`JSON imports transforms example test case 27`] = `
 Array [
   "/umd/index-browser-experimental-umd.js",
   "(function (global, factory) {
@@ -859,7 +683,7 @@ Array [
 ]
 `;
 
-exports[`JSON imports transforms example test case 40`] = `
+exports[`JSON imports transforms example test case 28`] = `
 Array [
   "/umd/index-browser-legacy-umd.js",
   "(function (global, factory) {
@@ -900,7 +724,7 @@ Array [
 ]
 `;
 
-exports[`JSON imports transforms example test case 41`] = `
+exports[`JSON imports transforms example test case 29`] = `
 Array [
   "/umd/index-browser-stable-umd.js",
   "(function (global, factory) {

--- a/tests/examples/__snapshots__/nodePolyfills.test.ts.snap
+++ b/tests/examples/__snapshots__/nodePolyfills.test.ts.snap
@@ -159,11 +159,7 @@ exports.test = test;
 exports[`Node polyfills transforms example test case 5`] = `
 Array [
   "/esm/index-browser-current-esm.js",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: browser, Support: current, Format: esm
-'use strict';
-
-function _typeof(obj) { \\"@babel/helpers - typeof\\"; if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
+  "function _typeof(obj) { \\"@babel/helpers - typeof\\"; if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
@@ -185,6 +181,8 @@ function _isNativeReflectConstruct() { if (typeof Reflect === \\"undefined\\" ||
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+// Generated with Packemon: https://packemon.dev
+// Platform: browser, Support: current, Format: esm
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -213,9 +211,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -305,7 +301,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -366,7 +361,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -725,10 +719,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -747,9 +740,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -911,8 +903,6 @@ Array [
   "/esm/index-browser-experimental-esm.js",
   "// Generated with Packemon: https://packemon.dev
 // Platform: browser, Support: experimental, Format: esm
-'use strict';
-
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -941,9 +931,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -1023,7 +1011,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -1082,7 +1069,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -1437,10 +1423,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -1459,9 +1444,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -1607,11 +1591,7 @@ export { Example, emitter, test };
 exports[`Node polyfills transforms example test case 7`] = `
 Array [
   "/esm/index-browser-legacy-esm.js",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: browser, Support: legacy, Format: esm
-'use strict';
-
-function _typeof(obj) { \\"@babel/helpers - typeof\\"; if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
+  "function _typeof(obj) { \\"@babel/helpers - typeof\\"; if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
@@ -1633,6 +1613,8 @@ function _isNativeReflectConstruct() { if (typeof Reflect === \\"undefined\\" ||
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+// Generated with Packemon: https://packemon.dev
+// Platform: browser, Support: legacy, Format: esm
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -1661,9 +1643,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -1753,7 +1733,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -1814,7 +1793,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -2173,10 +2151,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -2195,9 +2172,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -2357,11 +2333,7 @@ export { Example, emitter, test };
 exports[`Node polyfills transforms example test case 8`] = `
 Array [
   "/esm/index-browser-stable-esm.js",
-  "// Generated with Packemon: https://packemon.dev
-// Platform: browser, Support: stable, Format: esm
-'use strict';
-
-function _typeof(obj) { \\"@babel/helpers - typeof\\"; if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
+  "function _typeof(obj) { \\"@babel/helpers - typeof\\"; if (typeof Symbol === \\"function\\" && typeof Symbol.iterator === \\"symbol\\") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === \\"function\\" && obj.constructor === Symbol && obj !== Symbol.prototype ? \\"symbol\\" : typeof obj; }; } return _typeof(obj); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError(\\"Cannot call a class as a function\\"); } }
 
@@ -2383,6 +2355,8 @@ function _isNativeReflectConstruct() { if (typeof Reflect === \\"undefined\\" ||
 
 function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+// Generated with Packemon: https://packemon.dev
+// Platform: browser, Support: stable, Format: esm
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -2411,9 +2385,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -2503,7 +2475,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -2564,7 +2535,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -2923,10 +2893,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -2945,9 +2914,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -3136,8 +3104,6 @@ function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.g
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-'use strict';
-
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -3166,9 +3132,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -3258,7 +3222,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -3319,7 +3282,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -3678,10 +3640,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -3700,9 +3661,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -3871,8 +3831,6 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-'use strict';
-
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -3901,9 +3859,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -3983,7 +3939,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -4042,7 +3997,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -4397,10 +4351,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -4419,9 +4372,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -4598,8 +4550,6 @@ function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.g
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-'use strict';
-
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -4628,9 +4578,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -4720,7 +4668,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -4781,7 +4728,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -5140,10 +5086,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -5162,9 +5107,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -5355,8 +5299,6 @@ function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.g
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-'use strict';
-
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -5385,9 +5327,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -5477,7 +5417,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -5538,7 +5477,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -5897,10 +5835,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -5919,9 +5856,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -6090,8 +6026,6 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-'use strict';
-
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -6120,9 +6054,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -6202,7 +6134,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -6261,7 +6192,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -6616,10 +6546,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -6638,9 +6567,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -6795,8 +6723,6 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-'use strict';
-
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -6825,9 +6751,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -6907,7 +6831,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -6966,7 +6889,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -7321,10 +7243,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -7343,9 +7264,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -7522,8 +7442,6 @@ function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.g
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-'use strict';
-
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -7552,9 +7470,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -7644,7 +7560,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -7705,7 +7620,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -8064,10 +7978,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -8086,9 +7999,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -8257,8 +8169,6 @@ Array [
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
-'use strict';
-
 var domain; // This constructor is used to store event handlers. Instantiating this is
 // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
 // object (tested with v8 v4.9).
@@ -8287,9 +8197,7 @@ EventEmitter.init = function () {
 
   if (EventEmitter.usingDomains) {
     // if there is an active domain, then attach to it.
-    if (domain.active && !(this instanceof domain.Domain)) {
-      this.domain = domain.active;
-    }
+    if (domain.active) ;
   }
 
   if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -8369,7 +8277,6 @@ function emitMany(handler, isFn, self, args) {
 
 EventEmitter.prototype.emit = function emit(type) {
   var er, handler, len, args, i, events, domain;
-  var needDomainExit = false;
   var doError = type === 'error';
   events = this._events;
   if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -8428,7 +8335,6 @@ EventEmitter.prototype.emit = function emit(type) {
       emitMany(handler, isFn, this, args);
   }
 
-  if (needDomainExit) domain.exit();
   return true;
 };
 
@@ -8783,10 +8689,9 @@ function resolve() {
     return !!p;
   }), !resolvedAbsolute).join('/');
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-}
-
-; // path.normalize(path)
+} // path.normalize(path)
 // posix version
+
 
 function normalize(path) {
   var isPathAbsolute = isAbsolute(path),
@@ -8805,9 +8710,8 @@ function normalize(path) {
   }
 
   return (isPathAbsolute ? '/' : '') + path;
-}
+} // posix version
 
-; // posix version
 
 function isAbsolute(path) {
   return path.charAt(0) === '/';
@@ -9227,9 +9131,7 @@ Array [
     global.examples = mod.exports;
   }
 })(typeof globalThis !== \\"undefined\\" ? globalThis : typeof self !== \\"undefined\\" ? self : this, function (_exports) {
-  // Generated with Packemon: https://packemon.dev
-  // Platform: browser, Support: current, Format: umd
-  'use strict';
+  \\"use strict\\";
 
   Object.defineProperty(_exports, \\"__esModule\\", {
     value: true
@@ -9256,6 +9158,8 @@ Array [
 
   function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+  // Generated with Packemon: https://packemon.dev
+  // Platform: browser, Support: current, Format: umd
   var domain; // This constructor is used to store event handlers. Instantiating this is
   // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
   // object (tested with v8 v4.9).
@@ -9284,9 +9188,7 @@ Array [
 
     if (EventEmitter.usingDomains) {
       // if there is an active domain, then attach to it.
-      if (domain.active && !(this instanceof domain.Domain)) {
-        this.domain = domain.active;
-      }
+      if (domain.active) ;
     }
 
     if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -9376,7 +9278,6 @@ Array [
 
   EventEmitter.prototype.emit = function emit(type) {
     var er, handler, len, args, i, events, domain;
-    var needDomainExit = false;
     var doError = type === 'error';
     events = this._events;
     if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -9437,7 +9338,6 @@ Array [
         emitMany(handler, isFn, this, args);
     }
 
-    if (needDomainExit) domain.exit();
     return true;
   };
 
@@ -9796,10 +9696,9 @@ Array [
       return !!p;
     }), !resolvedAbsolute).join('/');
     return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-  }
-
-  ; // path.normalize(path)
+  } // path.normalize(path)
   // posix version
+
 
   function normalize(path) {
     var isPathAbsolute = isAbsolute(path),
@@ -9818,9 +9717,8 @@ Array [
     }
 
     return (isPathAbsolute ? '/' : '') + path;
-  }
+  } // posix version
 
-  ; // posix version
 
   function isAbsolute(path) {
     return path.charAt(0) === '/';
@@ -9996,14 +9894,14 @@ Array [
     global.examples = mod.exports;
   }
 })(typeof globalThis !== \\"undefined\\" ? globalThis : typeof self !== \\"undefined\\" ? self : this, function (_exports) {
-  // Generated with Packemon: https://packemon.dev
-  // Platform: browser, Support: experimental, Format: umd
-  'use strict';
+  \\"use strict\\";
 
   Object.defineProperty(_exports, \\"__esModule\\", {
     value: true
   });
   _exports.test = _exports.emitter = _exports.Example = void 0;
+  // Generated with Packemon: https://packemon.dev
+  // Platform: browser, Support: experimental, Format: umd
   var domain; // This constructor is used to store event handlers. Instantiating this is
   // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
   // object (tested with v8 v4.9).
@@ -10032,9 +9930,7 @@ Array [
 
     if (EventEmitter.usingDomains) {
       // if there is an active domain, then attach to it.
-      if (domain.active && !(this instanceof domain.Domain)) {
-        this.domain = domain.active;
-      }
+      if (domain.active) ;
     }
 
     if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -10114,7 +10010,6 @@ Array [
 
   EventEmitter.prototype.emit = function emit(type) {
     var er, handler, len, args, i, events, domain;
-    var needDomainExit = false;
     var doError = type === 'error';
     events = this._events;
     if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -10173,7 +10068,6 @@ Array [
         emitMany(handler, isFn, this, args);
     }
 
-    if (needDomainExit) domain.exit();
     return true;
   };
 
@@ -10528,10 +10422,9 @@ Array [
       return !!p;
     }), !resolvedAbsolute).join('/');
     return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-  }
-
-  ; // path.normalize(path)
+  } // path.normalize(path)
   // posix version
+
 
   function normalize(path) {
     var isPathAbsolute = isAbsolute(path),
@@ -10550,9 +10443,8 @@ Array [
     }
 
     return (isPathAbsolute ? '/' : '') + path;
-  }
+  } // posix version
 
-  ; // posix version
 
   function isAbsolute(path) {
     return path.charAt(0) === '/';
@@ -10716,9 +10608,7 @@ Array [
     global.examples = mod.exports;
   }
 })(typeof globalThis !== \\"undefined\\" ? globalThis : typeof self !== \\"undefined\\" ? self : this, function (_exports) {
-  // Generated with Packemon: https://packemon.dev
-  // Platform: browser, Support: legacy, Format: umd
-  'use strict';
+  \\"use strict\\";
 
   Object.defineProperty(_exports, \\"__esModule\\", {
     value: true
@@ -10745,6 +10635,8 @@ Array [
 
   function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+  // Generated with Packemon: https://packemon.dev
+  // Platform: browser, Support: legacy, Format: umd
   var domain; // This constructor is used to store event handlers. Instantiating this is
   // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
   // object (tested with v8 v4.9).
@@ -10773,9 +10665,7 @@ Array [
 
     if (EventEmitter.usingDomains) {
       // if there is an active domain, then attach to it.
-      if (domain.active && !(this instanceof domain.Domain)) {
-        this.domain = domain.active;
-      }
+      if (domain.active) ;
     }
 
     if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -10865,7 +10755,6 @@ Array [
 
   EventEmitter.prototype.emit = function emit(type) {
     var er, handler, len, args, i, events, domain;
-    var needDomainExit = false;
     var doError = type === 'error';
     events = this._events;
     if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -10926,7 +10815,6 @@ Array [
         emitMany(handler, isFn, this, args);
     }
 
-    if (needDomainExit) domain.exit();
     return true;
   };
 
@@ -11285,10 +11173,9 @@ Array [
       return !!p;
     }), !resolvedAbsolute).join('/');
     return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-  }
-
-  ; // path.normalize(path)
+  } // path.normalize(path)
   // posix version
+
 
   function normalize(path) {
     var isPathAbsolute = isAbsolute(path),
@@ -11307,9 +11194,8 @@ Array [
     }
 
     return (isPathAbsolute ? '/' : '') + path;
-  }
+  } // posix version
 
-  ; // posix version
 
   function isAbsolute(path) {
     return path.charAt(0) === '/';
@@ -11487,9 +11373,7 @@ Array [
     global.examples = mod.exports;
   }
 })(typeof globalThis !== \\"undefined\\" ? globalThis : typeof self !== \\"undefined\\" ? self : this, function (_exports) {
-  // Generated with Packemon: https://packemon.dev
-  // Platform: browser, Support: stable, Format: umd
-  'use strict';
+  \\"use strict\\";
 
   Object.defineProperty(_exports, \\"__esModule\\", {
     value: true
@@ -11516,6 +11400,8 @@ Array [
 
   function _getPrototypeOf(o) { _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) { return o.__proto__ || Object.getPrototypeOf(o); }; return _getPrototypeOf(o); }
 
+  // Generated with Packemon: https://packemon.dev
+  // Platform: browser, Support: stable, Format: umd
   var domain; // This constructor is used to store event handlers. Instantiating this is
   // faster than explicitly calling \`Object.create(null)\` to get a \\"clean\\" empty
   // object (tested with v8 v4.9).
@@ -11544,9 +11430,7 @@ Array [
 
     if (EventEmitter.usingDomains) {
       // if there is an active domain, then attach to it.
-      if (domain.active && !(this instanceof domain.Domain)) {
-        this.domain = domain.active;
-      }
+      if (domain.active) ;
     }
 
     if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
@@ -11636,7 +11520,6 @@ Array [
 
   EventEmitter.prototype.emit = function emit(type) {
     var er, handler, len, args, i, events, domain;
-    var needDomainExit = false;
     var doError = type === 'error';
     events = this._events;
     if (events) doError = doError && events.error == null;else if (!doError) return false;
@@ -11697,7 +11580,6 @@ Array [
         emitMany(handler, isFn, this, args);
     }
 
-    if (needDomainExit) domain.exit();
     return true;
   };
 
@@ -12056,10 +11938,9 @@ Array [
       return !!p;
     }), !resolvedAbsolute).join('/');
     return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
-  }
-
-  ; // path.normalize(path)
+  } // path.normalize(path)
   // posix version
+
 
   function normalize(path) {
     var isPathAbsolute = isAbsolute(path),
@@ -12078,9 +11959,8 @@ Array [
     }
 
     return (isPathAbsolute ? '/' : '') + path;
-  }
+  } // posix version
 
-  ; // posix version
 
   function isAbsolute(path) {
     return path.charAt(0) === '/';

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-
 import fs from 'fs';
 import fsx from 'fs-extra';
 import { Path, PortablePath } from '@boost/common';
@@ -89,7 +87,6 @@ FORMATS.forEach((format) => {
       }
 
       builds.set(key, {
-        bundle: platform !== 'node',
         format,
         platform,
         support,

--- a/tests/rollup/config.test.ts
+++ b/tests/rollup/config.test.ts
@@ -104,10 +104,10 @@ describe('getRollupConfig()', () => {
 
   it('generates an output config for each build', () => {
     artifact.builds.push(
-      { bundle: false, format: 'lib', platform: 'node', support: 'stable' },
-      { bundle: true, format: 'lib', platform: 'browser', support: 'legacy' },
-      { bundle: true, format: 'esm', platform: 'browser', support: 'current' },
-      { bundle: false, format: 'mjs', platform: 'node', support: 'experimental' },
+      { format: 'lib', platform: 'node', support: 'stable' },
+      { format: 'lib', platform: 'browser', support: 'legacy' },
+      { format: 'esm', platform: 'browser', support: 'current' },
+      { format: 'mjs', platform: 'node', support: 'experimental' },
     );
 
     expect(getRollupConfig(artifact, {})).toEqual({
@@ -188,7 +188,7 @@ describe('getRollupConfig()', () => {
     artifact.outputName = 'server';
     artifact.platform = 'node';
     artifact.support = 'stable';
-    artifact.builds.push({ bundle: false, format: 'lib', platform: 'node', support: 'stable' });
+    artifact.builds.push({ format: 'lib', platform: 'node', support: 'stable' });
 
     expect(getRollupConfig(artifact, {})).toEqual({
       cache: undefined,
@@ -299,11 +299,7 @@ describe('getRollupOutputConfig()', () => {
 
   it('generates default output config', () => {
     expect(
-      getRollupOutputConfig(
-        artifact,
-        {},
-        { bundle: false, format: 'lib', platform: 'node', support: 'stable' },
-      ),
+      getRollupOutputConfig(artifact, {}, { format: 'lib', platform: 'node', support: 'stable' }),
     ).toEqual({
       assetFileNames: '../assets/[name]-[hash][extname]',
       banner: expect.any(String),

--- a/tests/rollup/config.test.ts
+++ b/tests/rollup/config.test.ts
@@ -127,7 +127,6 @@ describe('getRollupConfig()', () => {
           paths: {},
           plugins: [`babelOutput(${fixturePath}, *)`],
           preferConst: false,
-          preserveModules: true,
           sourcemap: true,
           sourcemapExcludeSources: true,
         },
@@ -143,7 +142,6 @@ describe('getRollupConfig()', () => {
           paths: {},
           plugins: [`babelOutput(${fixturePath}, *)`],
           preferConst: false,
-          preserveModules: false,
           sourcemap: true,
           sourcemapExcludeSources: true,
         },
@@ -158,7 +156,6 @@ describe('getRollupConfig()', () => {
           paths: {},
           plugins: [`babelOutput(${fixturePath}, *)`],
           preferConst: true,
-          preserveModules: false,
           sourcemap: true,
           sourcemapExcludeSources: true,
         },
@@ -173,13 +170,12 @@ describe('getRollupConfig()', () => {
           paths: {},
           plugins: [`babelOutput(${fixturePath}, *)`],
           preferConst: true,
-          preserveModules: true,
           sourcemap: true,
           sourcemapExcludeSources: true,
         },
       ],
       plugins: sharedPlugins,
-      treeshake: false,
+      treeshake: true,
     });
   });
 
@@ -207,7 +203,6 @@ describe('getRollupConfig()', () => {
           paths: {},
           plugins: [`babelOutput(${fixturePath}, *)`],
           preferConst: false,
-          preserveModules: true,
           sourcemap: true,
           sourcemapExcludeSources: true,
         },
@@ -312,7 +307,6 @@ describe('getRollupOutputConfig()', () => {
       paths: {},
       plugins: [`babelOutput(${fixturePath}, *)`],
       preferConst: false,
-      preserveModules: true,
       sourcemap: true,
       sourcemapExcludeSources: true,
     });
@@ -622,7 +616,6 @@ describe('getRollupOutputConfig()', () => {
       paths: {},
       plugins: [`babelOutput(${fixturePath}, FooBar)`],
       preferConst: true,
-      preserveModules: false,
       sourcemap: true,
       sourcemapExcludeSources: true,
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     "strict": true,
     "target": "es2020",
     "jsx": "react",
-    "outDir": "build2"
+    "outDir": "build"
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
The ideal goal for this project was to always use Rollup for bundling, as we can treeshake and optimize. However, not all projects should be bundled into a single file, for example, component libraries and ESLint rules/configs.

Rollup does not support "transform every source file and copy" type mechanism, so we need to avoid Rollup for this and use Babel directly.