### PR TITLE
breaking: Support ECMAScript as default formats.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
       "babel": "src/babel.ts",
       "bin": "src/bin.ts"
     },
+    "format": "lib",
     "platform": "node"
   },
   "devDependencies": {

--- a/src/CodeArtifact.ts
+++ b/src/CodeArtifact.ts
@@ -2,7 +2,6 @@ import { rollup, RollupCache } from 'rollup';
 import { Path, toArray } from '@boost/common';
 import { createDebugger, Debugger } from '@boost/debug';
 import { Artifact } from './Artifact';
-import { DEFAULT_FORMAT } from './constants';
 import { removeSourcePath } from './helpers/removeSourcePath';
 import { getRollupConfig } from './rollup/config';
 import {
@@ -84,7 +83,7 @@ export class CodeArtifact extends Artifact<CodeBuild> {
 
     await Promise.all(
       toArray(output).map(async (out, index) => {
-        const { originalFormat = DEFAULT_FORMAT, ...outOptions } = out;
+        const { originalFormat = 'lib', ...outOptions } = out;
 
         this.debug(' - Writing `%s` output', originalFormat);
 

--- a/src/Package.ts
+++ b/src/Package.ts
@@ -225,7 +225,7 @@ export class Package {
             }
 
             if (isEmpty) {
-              formats.push('lib');
+              formats.push('mjs');
             } else {
               formats = formats.filter((format) => (FORMATS_NODE as string[]).includes(format));
             }
@@ -234,7 +234,7 @@ export class Package {
           case 'browser':
           default:
             if (isEmpty) {
-              formats.push('lib', 'esm');
+              formats.push('esm');
 
               if (config.namespace) {
                 formats.push('umd');
@@ -353,7 +353,7 @@ export class Package {
         // Generate `main`, `module`, and `browser` fields
         if (artifact.inputs.index) {
           if (!mainEntry || artifact.platform === 'node') {
-            mainEntry = artifact.findEntryPoint(['lib', 'cjs', 'mjs'], 'index');
+            mainEntry = artifact.findEntryPoint(['lib', 'cjs', 'mjs', 'esm'], 'index');
           }
 
           if (!moduleEntry) {

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -3,16 +3,16 @@ import { TransformOptions as ConfigStructure } from '@babel/core';
 import { Path, toArray } from '@boost/common';
 import { FeatureFlags } from './types';
 import {
-	CodeArtifact,
-	DEFAULT_SUPPORT,
-	Format,
-	getBabelInputConfig,
-	getBabelOutputConfig,
-	Package,
-	PackemonPackage,
-	Platform,
-	Project,
-	Support,
+  CodeArtifact,
+  DEFAULT_SUPPORT,
+  Format,
+  getBabelInputConfig,
+  getBabelOutputConfig,
+  Package,
+  PackemonPackage,
+  Platform,
+  Project,
+  Support,
 } from '.';
 
 const format = (process.env.PACKEMON_FORMAT ?? 'lib') as Format;
@@ -20,66 +20,66 @@ const support = (process.env.PACKEMON_SUPPORT ?? DEFAULT_SUPPORT) as Support;
 const project = new Project(process.cwd());
 
 function getBabelConfig(artifact: CodeArtifact, featureFlags: FeatureFlags): ConfigStructure {
-	const inputConfig = getBabelInputConfig(artifact, featureFlags);
-	const outputConfig = getBabelOutputConfig(
-		artifact.platform,
-		artifact.support,
-		artifact.builds[0].format,
-		featureFlags,
-	);
+  const inputConfig = getBabelInputConfig(artifact, featureFlags);
+  const outputConfig = getBabelOutputConfig(
+    artifact.platform,
+    artifact.support,
+    artifact.builds[0].format,
+    featureFlags,
+  );
 
-	return {
-		// Input must come first
-		plugins: [...inputConfig.plugins!, ...outputConfig.plugins!],
-		// Env must come first
-		presets: [...outputConfig.presets!, ...inputConfig.presets!],
-	};
+  return {
+    // Input must come first
+    plugins: [...inputConfig.plugins!, ...outputConfig.plugins!],
+    // Env must come first
+    presets: [...outputConfig.presets!, ...inputConfig.presets!],
+  };
 }
 
 export function createConfig(folder: string): ConfigStructure {
-	const path = new Path(folder);
-	const contents = fs.readJsonSync(path.append('package.json').path()) as PackemonPackage;
+  const path = new Path(folder);
+  const contents = fs.readJsonSync(path.append('package.json').path()) as PackemonPackage;
 
-	// Create package and configs
-	const pkg = new Package(project, path, contents);
+  // Create package and configs
+  const pkg = new Package(project, path, contents);
 
-	if (pkg.packageJson.packemon) {
-		pkg.setConfigs(toArray(pkg.packageJson.packemon));
-	}
+  if (pkg.packageJson.packemon) {
+    pkg.setConfigs(toArray(pkg.packageJson.packemon));
+  }
 
-	// Determine the lowest platform to support
-	const platforms = pkg.configs.map((config) => config.platform);
-	let lowestPlatform: Platform = 'node';
+  // Determine the lowest platform to support
+  const platforms = pkg.configs.map((config) => config.platform);
+  let lowestPlatform: Platform = 'node';
 
-	// istanbul ignore next
-	if (platforms.includes('browser')) {
-		lowestPlatform = 'browser';
-	} else if (platforms.includes('native')) {
-		lowestPlatform = 'native';
-	}
+  // istanbul ignore next
+  if (platforms.includes('browser')) {
+    lowestPlatform = 'browser';
+  } else if (platforms.includes('native')) {
+    lowestPlatform = 'native';
+  }
 
-	// Generate artifact and builds
-	const artifact = new CodeArtifact(pkg, [{ format }]);
-	artifact.bundle = false;
-	artifact.platform = lowestPlatform;
-	artifact.support = support;
+  // Generate artifact and builds
+  const artifact = new CodeArtifact(pkg, [{ format }]);
+  artifact.bundle = false;
+  artifact.platform = lowestPlatform;
+  artifact.support = support;
 
-	return getBabelConfig(artifact, pkg.getFeatureFlags());
+  return getBabelConfig(artifact, pkg.getFeatureFlags());
 }
 
 export function createRootConfig(): ConfigStructure {
-	const config = createConfig(process.cwd());
+  const config = createConfig(process.cwd());
 
-	return {
-		...config,
-		babelrc: true,
-		babelrcRoots: project.getWorkspaceGlobs({ relative: true }),
-		// Support React Native libraries by default
-		overrides: [
-			{
-				presets: ['@babel/preset-flow'],
-				test: /node_modules\/((jest-)?react-native|@react-native(-community)?)/iu,
-			},
-		],
-	};
+  return {
+    ...config,
+    babelrc: true,
+    babelrcRoots: project.getWorkspaceGlobs({ relative: true }),
+    // Support React Native libraries by default
+    overrides: [
+      {
+        presets: ['@babel/preset-flow'],
+        test: /node_modules\/((jest-)?react-native|@react-native(-community)?)/iu,
+      },
+    ],
+  };
 }

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -3,84 +3,83 @@ import { TransformOptions as ConfigStructure } from '@babel/core';
 import { Path, toArray } from '@boost/common';
 import { FeatureFlags } from './types';
 import {
-  CodeArtifact,
-  DEFAULT_FORMAT,
-  DEFAULT_SUPPORT,
-  Format,
-  getBabelInputConfig,
-  getBabelOutputConfig,
-  Package,
-  PackemonPackage,
-  Platform,
-  Project,
-  Support,
+	CodeArtifact,
+	DEFAULT_SUPPORT,
+	Format,
+	getBabelInputConfig,
+	getBabelOutputConfig,
+	Package,
+	PackemonPackage,
+	Platform,
+	Project,
+	Support,
 } from '.';
 
-const format = (process.env.PACKEMON_FORMAT ?? DEFAULT_FORMAT) as Format;
+const format = (process.env.PACKEMON_FORMAT ?? 'lib') as Format;
 const support = (process.env.PACKEMON_SUPPORT ?? DEFAULT_SUPPORT) as Support;
 const project = new Project(process.cwd());
 
 function getBabelConfig(artifact: CodeArtifact, featureFlags: FeatureFlags): ConfigStructure {
-  const inputConfig = getBabelInputConfig(artifact, featureFlags);
-  const outputConfig = getBabelOutputConfig(
-    artifact.platform,
-    artifact.support,
-    artifact.builds[0].format,
-    featureFlags,
-  );
+	const inputConfig = getBabelInputConfig(artifact, featureFlags);
+	const outputConfig = getBabelOutputConfig(
+		artifact.platform,
+		artifact.support,
+		artifact.builds[0].format,
+		featureFlags,
+	);
 
-  return {
-    // Input must come first
-    plugins: [...inputConfig.plugins!, ...outputConfig.plugins!],
-    // Env must come first
-    presets: [...outputConfig.presets!, ...inputConfig.presets!],
-  };
+	return {
+		// Input must come first
+		plugins: [...inputConfig.plugins!, ...outputConfig.plugins!],
+		// Env must come first
+		presets: [...outputConfig.presets!, ...inputConfig.presets!],
+	};
 }
 
 export function createConfig(folder: string): ConfigStructure {
-  const path = new Path(folder);
-  const contents = fs.readJsonSync(path.append('package.json').path()) as PackemonPackage;
+	const path = new Path(folder);
+	const contents = fs.readJsonSync(path.append('package.json').path()) as PackemonPackage;
 
-  // Create package and configs
-  const pkg = new Package(project, path, contents);
+	// Create package and configs
+	const pkg = new Package(project, path, contents);
 
-  if (pkg.packageJson.packemon) {
-    pkg.setConfigs(toArray(pkg.packageJson.packemon));
-  }
+	if (pkg.packageJson.packemon) {
+		pkg.setConfigs(toArray(pkg.packageJson.packemon));
+	}
 
-  // Determine the lowest platform to support
-  const platforms = pkg.configs.map((config) => config.platform);
-  let lowestPlatform: Platform = 'node';
+	// Determine the lowest platform to support
+	const platforms = pkg.configs.map((config) => config.platform);
+	let lowestPlatform: Platform = 'node';
 
-  // istanbul ignore next
-  if (platforms.includes('browser')) {
-    lowestPlatform = 'browser';
-  } else if (platforms.includes('native')) {
-    lowestPlatform = 'native';
-  }
+	// istanbul ignore next
+	if (platforms.includes('browser')) {
+		lowestPlatform = 'browser';
+	} else if (platforms.includes('native')) {
+		lowestPlatform = 'native';
+	}
 
-  // Generate artifact and builds
-  const artifact = new CodeArtifact(pkg, [{ format }]);
-  artifact.bundle = false;
-  artifact.platform = lowestPlatform;
-  artifact.support = support;
+	// Generate artifact and builds
+	const artifact = new CodeArtifact(pkg, [{ format }]);
+	artifact.bundle = false;
+	artifact.platform = lowestPlatform;
+	artifact.support = support;
 
-  return getBabelConfig(artifact, pkg.getFeatureFlags());
+	return getBabelConfig(artifact, pkg.getFeatureFlags());
 }
 
 export function createRootConfig(): ConfigStructure {
-  const config = createConfig(process.cwd());
+	const config = createConfig(process.cwd());
 
-  return {
-    ...config,
-    babelrc: true,
-    babelrcRoots: project.getWorkspaceGlobs({ relative: true }),
-    // Support React Native libraries by default
-    overrides: [
-      {
-        presets: ['@babel/preset-flow'],
-        test: /node_modules\/((jest-)?react-native|@react-native(-community)?)/iu,
-      },
-    ],
-  };
+	return {
+		...config,
+		babelrc: true,
+		babelrcRoots: project.getWorkspaceGlobs({ relative: true }),
+		// Support React Native libraries by default
+		overrides: [
+			{
+				presets: ['@babel/preset-flow'],
+				test: /node_modules\/((jest-)?react-native|@react-native(-community)?)/iu,
+			},
+		],
+	};
 }

--- a/src/commands/Init.tsx
+++ b/src/commands/Init.tsx
@@ -10,94 +10,94 @@ import { PackemonPackage, PackemonPackageConfig } from '../types';
 import { BaseCommand } from './Base';
 
 export interface InitOptions {
-	force: boolean;
-	skipPrivate: boolean;
+  force: boolean;
+  skipPrivate: boolean;
 }
 
 @Config('init', 'Initialize and configure Packemon for packages')
 export class InitCommand extends BaseCommand<InitOptions> {
-	@Arg.Flag('Override already configured packages')
-	force: boolean = false;
+  @Arg.Flag('Override already configured packages')
+  force: boolean = false;
 
-	async run() {
-		const packages = await this.packemon.findPackagesInProject(this.getBuildOptions());
+  async run() {
+    const packages = await this.packemon.findPackagesInProject(this.getBuildOptions());
 
-		const unconfiguredPackages = this.force
-			? packages
-			: packages.filter((pkg) => !pkg.package.packemon);
+    const unconfiguredPackages = this.force
+      ? packages
+      : packages.filter((pkg) => !pkg.package.packemon);
 
-		if (unconfiguredPackages.length === 0) {
-			if (packages.length === 0) {
-				this.log.error('No packages found in project.');
-			} else {
-				this.log.info('All packages have been configured. Pass --force to override.');
-			}
+    if (unconfiguredPackages.length === 0) {
+      if (packages.length === 0) {
+        this.log.error('No packages found in project.');
+      } else {
+        this.log.info('All packages have been configured. Pass --force to override.');
+      }
 
-			return Promise.resolve();
-		}
+      return Promise.resolve();
+    }
 
-		return (
-			<Init
-				packageNames={unconfiguredPackages.map((pkg) => pkg.package.name)}
-				onComplete={(configs) => this.writeConfigsToPackageJsons(unconfiguredPackages, configs)}
-			/>
-		);
-	}
+    return (
+      <Init
+        packageNames={unconfiguredPackages.map((pkg) => pkg.package.name)}
+        onComplete={(configs) => this.writeConfigsToPackageJsons(unconfiguredPackages, configs)}
+      />
+    );
+  }
 
-	// eslint-disable-next-line complexity
-	formatConfigObject({
-		format,
-		inputs,
-		namespace,
-		platform,
-		support,
-	}: PackemonPackageConfig): PackemonPackageConfig {
-		const config: PackemonPackageConfig = {};
+  // eslint-disable-next-line complexity
+  formatConfigObject({
+    format,
+    inputs,
+    namespace,
+    platform,
+    support,
+  }: PackemonPackageConfig): PackemonPackageConfig {
+    const config: PackemonPackageConfig = {};
 
-		if (format) {
-			if (Array.isArray(format) && format.length === 1) {
-				[config.format] = format;
-			} else {
-				config.format = format;
-			}
-		}
+    if (format) {
+      if (Array.isArray(format) && format.length === 1) {
+        [config.format] = format;
+      } else {
+        config.format = format;
+      }
+    }
 
-		if (inputs && !(Object.keys(inputs).length === 1 && inputs.index === DEFAULT_INPUT)) {
-			config.inputs = inputs;
-		}
+    if (inputs && !(Object.keys(inputs).length === 1 && inputs.index === DEFAULT_INPUT)) {
+      config.inputs = inputs;
+    }
 
-		if (namespace) {
-			config.namespace = namespace;
-		}
+    if (namespace) {
+      config.namespace = namespace;
+    }
 
-		if (platform) {
-			if (Array.isArray(platform) && platform.length === 1) {
-				[config.platform] = platform;
-			} else {
-				config.platform = platform;
-			}
-		}
+    if (platform) {
+      if (Array.isArray(platform) && platform.length === 1) {
+        [config.platform] = platform;
+      } else {
+        config.platform = platform;
+      }
+    }
 
-		if (support && support !== DEFAULT_SUPPORT) {
-			config.support = support;
-		}
+    if (support && support !== DEFAULT_SUPPORT) {
+      config.support = support;
+    }
 
-		return config;
-	}
+    return config;
+  }
 
-	async writeConfigsToPackageJsons(
-		packages: WorkspacePackage<PackemonPackage>[],
-		configs: Record<string, PackemonPackageConfig>,
-	) {
-		await Promise.all(
-			packages.map((item) => {
-				const pkg = new Package(this.packemon.project, new Path(item.metadata.packagePath), {
-					...item.package,
-					packemon: this.formatConfigObject(configs[item.package.name]),
-				});
+  async writeConfigsToPackageJsons(
+    packages: WorkspacePackage<PackemonPackage>[],
+    configs: Record<string, PackemonPackageConfig>,
+  ) {
+    await Promise.all(
+      packages.map((item) => {
+        const pkg = new Package(this.packemon.project, new Path(item.metadata.packagePath), {
+          ...item.package,
+          packemon: this.formatConfigObject(configs[item.package.name]),
+        });
 
-				return pkg.syncPackageJson();
-			}),
-		);
-	}
+        return pkg.syncPackageJson();
+      }),
+    );
+  }
 }

--- a/src/commands/Init.tsx
+++ b/src/commands/Init.tsx
@@ -4,102 +4,100 @@ import React from 'react';
 import { Arg, Config } from '@boost/cli';
 import { Path, WorkspacePackage } from '@boost/common';
 import { Init } from '../components/Init';
-import { DEFAULT_FORMAT, DEFAULT_INPUT, DEFAULT_SUPPORT } from '../constants';
+import { DEFAULT_INPUT, DEFAULT_SUPPORT } from '../constants';
 import { Package } from '../Package';
 import { PackemonPackage, PackemonPackageConfig } from '../types';
 import { BaseCommand } from './Base';
 
 export interface InitOptions {
-  force: boolean;
-  skipPrivate: boolean;
+	force: boolean;
+	skipPrivate: boolean;
 }
 
 @Config('init', 'Initialize and configure Packemon for packages')
 export class InitCommand extends BaseCommand<InitOptions> {
-  @Arg.Flag('Override already configured packages')
-  force: boolean = false;
+	@Arg.Flag('Override already configured packages')
+	force: boolean = false;
 
-  async run() {
-    const packages = await this.packemon.findPackagesInProject(this.getBuildOptions());
+	async run() {
+		const packages = await this.packemon.findPackagesInProject(this.getBuildOptions());
 
-    const unconfiguredPackages = this.force
-      ? packages
-      : packages.filter((pkg) => !pkg.package.packemon);
+		const unconfiguredPackages = this.force
+			? packages
+			: packages.filter((pkg) => !pkg.package.packemon);
 
-    if (unconfiguredPackages.length === 0) {
-      if (packages.length === 0) {
-        this.log.error('No packages found in project.');
-      } else {
-        this.log.info('All packages have been configured. Pass --force to override.');
-      }
+		if (unconfiguredPackages.length === 0) {
+			if (packages.length === 0) {
+				this.log.error('No packages found in project.');
+			} else {
+				this.log.info('All packages have been configured. Pass --force to override.');
+			}
 
-      return Promise.resolve();
-    }
+			return Promise.resolve();
+		}
 
-    return (
-      <Init
-        packageNames={unconfiguredPackages.map((pkg) => pkg.package.name)}
-        onComplete={(configs) => this.writeConfigsToPackageJsons(unconfiguredPackages, configs)}
-      />
-    );
-  }
+		return (
+			<Init
+				packageNames={unconfiguredPackages.map((pkg) => pkg.package.name)}
+				onComplete={(configs) => this.writeConfigsToPackageJsons(unconfiguredPackages, configs)}
+			/>
+		);
+	}
 
-  // eslint-disable-next-line complexity
-  formatConfigObject({
-    format,
-    inputs,
-    namespace,
-    platform,
-    support,
-  }: PackemonPackageConfig): PackemonPackageConfig {
-    const config: PackemonPackageConfig = {};
+	// eslint-disable-next-line complexity
+	formatConfigObject({
+		format,
+		inputs,
+		namespace,
+		platform,
+		support,
+	}: PackemonPackageConfig): PackemonPackageConfig {
+		const config: PackemonPackageConfig = {};
 
-    if (format) {
-      if (Array.isArray(format) && format.length === 1) {
-        if (format[0] !== DEFAULT_FORMAT) {
-          [config.format] = format;
-        }
-      } else {
-        config.format = format;
-      }
-    }
+		if (format) {
+			if (Array.isArray(format) && format.length === 1) {
+				[config.format] = format;
+			} else {
+				config.format = format;
+			}
+		}
 
-    if (inputs && !(Object.keys(inputs).length === 1 && inputs.index === DEFAULT_INPUT)) {
-      config.inputs = inputs;
-    }
+		if (inputs && !(Object.keys(inputs).length === 1 && inputs.index === DEFAULT_INPUT)) {
+			config.inputs = inputs;
+		}
 
-    if (namespace) {
-      config.namespace = namespace;
-    }
+		if (namespace) {
+			config.namespace = namespace;
+		}
 
-    if (platform) {
-      if (Array.isArray(platform) && platform.length === 1) {
-        [config.platform] = platform;
-      } else {
-        config.platform = platform;
-      }
-    }
+		if (platform) {
+			if (Array.isArray(platform) && platform.length === 1) {
+				[config.platform] = platform;
+			} else {
+				config.platform = platform;
+			}
+		}
 
-    if (support && support !== DEFAULT_SUPPORT) {
-      config.support = support;
-    }
+		if (support && support !== DEFAULT_SUPPORT) {
+			config.support = support;
+		}
 
-    return config;
-  }
+		return config;
+	}
 
-  async writeConfigsToPackageJsons(
-    packages: WorkspacePackage<PackemonPackage>[],
-    configs: Record<string, PackemonPackageConfig>,
-  ) {
-    await Promise.all(
-      packages.map((item) => {
-        const pkg = new Package(this.packemon.project, new Path(item.metadata.packagePath), {
-          ...item.package,
-          packemon: this.formatConfigObject(configs[item.package.name]),
-        });
+	async writeConfigsToPackageJsons(
+		packages: WorkspacePackage<PackemonPackage>[],
+		configs: Record<string, PackemonPackageConfig>,
+	) {
+		await Promise.all(
+			packages.map((item) => {
+				const pkg = new Package(this.packemon.project, new Path(item.metadata.packagePath), {
+					...item.package,
+					packemon: this.formatConfigObject(configs[item.package.name]),
+				});
 
-        return pkg.syncPackageJson();
-      }),
-    );
-  }
+				return pkg.syncPackageJson();
+			}),
+		);
+	}
 }

--- a/src/components/Init/PackageForm.tsx
+++ b/src/components/Init/PackageForm.tsx
@@ -12,7 +12,11 @@ function getSupportVersions(platforms: Platform[], support: Support): string {
   return applyStyle([...getVersionsCombo(platforms, support)].sort().join(', '), 'muted');
 }
 
-const FORMAT_LIST: Format[] = [];
+const DEFAULT_FORMATS: Record<Platform, Format[]> = {
+  browser: ['esm'],
+  native: ['lib'],
+  node: ['mjs'],
+};
 
 export function PackageForm({ onSubmit }: PackageFormProps) {
   const [platform, setPlatform] = useState<Platform[]>([]);
@@ -164,7 +168,7 @@ export function PackageForm({ onSubmit }: PackageFormProps) {
       />
 
       <MultiSelect<Format>
-        defaultSelected={FORMAT_LIST}
+        defaultSelected={DEFAULT_FORMATS[platform[0]]}
         label="Formats to build?"
         options={formatOptions}
         validate={validateFormat}

--- a/src/components/Init/PackageForm.tsx
+++ b/src/components/Init/PackageForm.tsx
@@ -1,186 +1,186 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { applyStyle, Input, MultiSelect, Select, SelectOptionLike } from '@boost/cli';
-import { DEFAULT_FORMAT, DEFAULT_INPUT, DEFAULT_SUPPORT } from '../../constants';
+import { DEFAULT_INPUT, DEFAULT_SUPPORT } from '../../constants';
 import { Format, PackemonPackageConfig, Platform, Support } from '../../types';
 import { getVersionsCombo } from '../Environment';
 
 export interface PackageFormProps {
-  onSubmit: (config: PackemonPackageConfig) => void;
+	onSubmit: (config: PackemonPackageConfig) => void;
 }
 
 function getSupportVersions(platforms: Platform[], support: Support): string {
-  return applyStyle([...getVersionsCombo(platforms, support)].sort().join(', '), 'muted');
+	return applyStyle([...getVersionsCombo(platforms, support)].sort().join(', '), 'muted');
 }
 
-const FORMAT_LIST = [DEFAULT_FORMAT];
+const FORMAT_LIST: Format[] = [];
 
 export function PackageForm({ onSubmit }: PackageFormProps) {
-  const [platform, setPlatform] = useState<Platform[]>([]);
-  const [support, setSupport] = useState<Support>(DEFAULT_SUPPORT);
-  const [format, setFormat] = useState<Format[]>([]);
-  const [input, setInput] = useState<string>('');
-  const [namespace, setNamespace] = useState('');
+	const [platform, setPlatform] = useState<Platform[]>([]);
+	const [support, setSupport] = useState<Support>(DEFAULT_SUPPORT);
+	const [format, setFormat] = useState<Format[]>([]);
+	const [input, setInput] = useState<string>('');
+	const [namespace, setNamespace] = useState('');
 
-  // Submit once all values are acceptable
-  useEffect(() => {
-    const hasUMD = format.includes('umd');
+	// Submit once all values are acceptable
+	useEffect(() => {
+		const hasUMD = format.includes('umd');
 
-    if (
-      platform.length > 0 &&
-      format.length > 0 &&
-      support &&
-      input &&
-      ((hasUMD && namespace) || (!hasUMD && !namespace))
-    ) {
-      const result = {
-        format,
-        inputs: { index: input },
-        namespace,
-        platform,
-        support,
-      };
+		if (
+			platform.length > 0 &&
+			format.length > 0 &&
+			support &&
+			input &&
+			((hasUMD && namespace) || (!hasUMD && !namespace))
+		) {
+			const result = {
+				format,
+				inputs: { index: input },
+				namespace,
+				platform,
+				support,
+			};
 
-      // Delay submission or focus API crashes
-      // https://github.com/vadimdemedes/ink/pull/404
-      setTimeout(() => {
-        onSubmit(result);
-      }, 100);
+			// Delay submission or focus API crashes
+			// https://github.com/vadimdemedes/ink/pull/404
+			setTimeout(() => {
+				onSubmit(result);
+			}, 100);
 
-      // Reset state for the next package
-      setPlatform([]);
-      setSupport(DEFAULT_SUPPORT);
-      setFormat([]);
-      setInput('');
-      setNamespace('');
-    }
-  }, [format, input, namespace, onSubmit, platform, support]);
+			// Reset state for the next package
+			setPlatform([]);
+			setSupport(DEFAULT_SUPPORT);
+			setFormat([]);
+			setInput('');
+			setNamespace('');
+		}
+	}, [format, input, namespace, onSubmit, platform, support]);
 
-  // PLATFORM
+	// PLATFORM
 
-  const platformOptions = useMemo<SelectOptionLike<Platform>[]>(
-    () => [
-      { label: 'Browsers', value: 'browser' },
-      { label: 'Node', value: 'node' },
-      { label: 'React Native', value: 'native' },
-    ],
-    [],
-  );
+	const platformOptions = useMemo<SelectOptionLike<Platform>[]>(
+		() => [
+			{ label: 'Browsers', value: 'browser' },
+			{ label: 'Node', value: 'node' },
+			{ label: 'React Native', value: 'native' },
+		],
+		[],
+	);
 
-  const validatePlatform = useCallback((value: Platform[]) => {
-    if (value.length === 0) {
-      throw new Error('Please select at least 1 platform');
-    }
-  }, []);
+	const validatePlatform = useCallback((value: Platform[]) => {
+		if (value.length === 0) {
+			throw new Error('Please select at least 1 platform');
+		}
+	}, []);
 
-  // SUPPORT
+	// SUPPORT
 
-  const supportOptions = useMemo<SelectOptionLike<Support>[]>(
-    () => [
-      {
-        label: `Legacy ${getSupportVersions(platform, 'legacy')}`,
-        value: 'legacy',
-      },
-      {
-        label: `Stable ${getSupportVersions(platform, 'stable')}`,
-        value: 'stable',
-      },
-      {
-        label: `Current ${getSupportVersions(platform, 'current')}`,
-        value: 'current',
-      },
-      {
-        label: `Experimental ${getSupportVersions(platform, 'experimental')}`,
-        value: 'experimental',
-      },
-    ],
-    [platform],
-  );
+	const supportOptions = useMemo<SelectOptionLike<Support>[]>(
+		() => [
+			{
+				label: `Legacy ${getSupportVersions(platform, 'legacy')}`,
+				value: 'legacy',
+			},
+			{
+				label: `Stable ${getSupportVersions(platform, 'stable')}`,
+				value: 'stable',
+			},
+			{
+				label: `Current ${getSupportVersions(platform, 'current')}`,
+				value: 'current',
+			},
+			{
+				label: `Experimental ${getSupportVersions(platform, 'experimental')}`,
+				value: 'experimental',
+			},
+		],
+		[platform],
+	);
 
-  const validateSupport = useCallback((value: Support) => {
-    if (!value) {
-      throw new Error('Please select a supported environment');
-    }
-  }, []);
+	const validateSupport = useCallback((value: Support) => {
+		if (!value) {
+			throw new Error('Please select a supported environment');
+		}
+	}, []);
 
-  // FORMAT
+	// FORMAT
 
-  const formatOptions = useMemo(() => {
-    const options: SelectOptionLike<Format>[] = [{ label: 'Shared CommonJS', value: 'lib' }];
+	const formatOptions = useMemo(() => {
+		const options: SelectOptionLike<Format>[] = [{ label: 'Shared CommonJS', value: 'lib' }];
 
-    if (platform.includes('node')) {
-      options.push(
-        { label: `Node - CommonJS ${applyStyle('(.cjs)', 'muted')}`, value: 'cjs' },
-        { label: `Node - ECMAScript ${applyStyle('(.mjs)', 'muted')}`, value: 'mjs' },
-      );
-    }
+		if (platform.includes('node')) {
+			options.push(
+				{ label: `Node - CommonJS ${applyStyle('(.cjs)', 'muted')}`, value: 'cjs' },
+				{ label: `Node - ECMAScript ${applyStyle('(.mjs)', 'muted')}`, value: 'mjs' },
+			);
+		}
 
-    if (platform.includes('browser')) {
-      options.push(
-        { label: 'Browser - ECMAScript', value: 'esm' },
-        { label: 'Browser - UMD', value: 'umd' },
-      );
-    }
+		if (platform.includes('browser')) {
+			options.push(
+				{ label: 'Browser - ECMAScript', value: 'esm' },
+				{ label: 'Browser - UMD', value: 'umd' },
+			);
+		}
 
-    return options;
-  }, [platform]);
+		return options;
+	}, [platform]);
 
-  const validateFormat = useCallback((value: Format[]) => {
-    if (value.length === 0) {
-      throw new Error('Please select at least 1 format');
-    }
-  }, []);
+	const validateFormat = useCallback((value: Format[]) => {
+		if (value.length === 0) {
+			throw new Error('Please select at least 1 format');
+		}
+	}, []);
 
-  // INPUT
+	// INPUT
 
-  const validateInput = useCallback((value: string) => {
-    if (!value || !value.match(/[-_a-z\d./\\]+/iu)) {
-      throw new Error('Must be a valid file path');
-    }
-  }, []);
+	const validateInput = useCallback((value: string) => {
+		if (!value || !value.match(/[-_a-z\d./\\]+/iu)) {
+			throw new Error('Must be a valid file path');
+		}
+	}, []);
 
-  // NAMESPACE
+	// NAMESPACE
 
-  const validateNamespace = useCallback((value: string) => {
-    if (!value || !value.match(/[a-z]\w+/iu)) {
-      throw new Error('Must be in pascal-case or camel-case and start with an alpha character');
-    }
-  }, []);
+	const validateNamespace = useCallback((value: string) => {
+		if (!value || !value.match(/[a-z]\w+/iu)) {
+			throw new Error('Must be in pascal-case or camel-case and start with an alpha character');
+		}
+	}, []);
 
-  return (
-    <>
-      <MultiSelect<Platform>
-        label="Platforms to target?"
-        options={platformOptions}
-        validate={validatePlatform}
-        onSubmit={setPlatform}
-      />
+	return (
+		<>
+			<MultiSelect<Platform>
+				label="Platforms to target?"
+				options={platformOptions}
+				validate={validatePlatform}
+				onSubmit={setPlatform}
+			/>
 
-      <Select<Support>
-        defaultSelected={DEFAULT_SUPPORT}
-        label="Environment to support?"
-        options={supportOptions}
-        validate={validateSupport}
-        onSubmit={setSupport}
-      />
+			<Select<Support>
+				defaultSelected={DEFAULT_SUPPORT}
+				label="Environment to support?"
+				options={supportOptions}
+				validate={validateSupport}
+				onSubmit={setSupport}
+			/>
 
-      <MultiSelect<Format>
-        defaultSelected={FORMAT_LIST}
-        label="Formats to build?"
-        options={formatOptions}
-        validate={validateFormat}
-        onSubmit={setFormat}
-      />
+			<MultiSelect<Format>
+				defaultSelected={FORMAT_LIST}
+				label="Formats to build?"
+				options={formatOptions}
+				validate={validateFormat}
+				onSubmit={setFormat}
+			/>
 
-      <Input
-        defaultValue={DEFAULT_INPUT}
-        label="Main entry point?"
-        validate={validateInput}
-        onSubmit={setInput}
-      />
+			<Input
+				defaultValue={DEFAULT_INPUT}
+				label="Main entry point?"
+				validate={validateInput}
+				onSubmit={setInput}
+			/>
 
-      {format.includes('umd') && (
-        <Input label="UMD namespace?" validate={validateNamespace} onSubmit={setNamespace} />
-      )}
-    </>
-  );
+			{format.includes('umd') && (
+				<Input label="UMD namespace?" validate={validateNamespace} onSubmit={setNamespace} />
+			)}
+		</>
+	);
 }

--- a/src/components/Init/PackageForm.tsx
+++ b/src/components/Init/PackageForm.tsx
@@ -5,182 +5,182 @@ import { Format, PackemonPackageConfig, Platform, Support } from '../../types';
 import { getVersionsCombo } from '../Environment';
 
 export interface PackageFormProps {
-	onSubmit: (config: PackemonPackageConfig) => void;
+  onSubmit: (config: PackemonPackageConfig) => void;
 }
 
 function getSupportVersions(platforms: Platform[], support: Support): string {
-	return applyStyle([...getVersionsCombo(platforms, support)].sort().join(', '), 'muted');
+  return applyStyle([...getVersionsCombo(platforms, support)].sort().join(', '), 'muted');
 }
 
 const FORMAT_LIST: Format[] = [];
 
 export function PackageForm({ onSubmit }: PackageFormProps) {
-	const [platform, setPlatform] = useState<Platform[]>([]);
-	const [support, setSupport] = useState<Support>(DEFAULT_SUPPORT);
-	const [format, setFormat] = useState<Format[]>([]);
-	const [input, setInput] = useState<string>('');
-	const [namespace, setNamespace] = useState('');
+  const [platform, setPlatform] = useState<Platform[]>([]);
+  const [support, setSupport] = useState<Support>(DEFAULT_SUPPORT);
+  const [format, setFormat] = useState<Format[]>([]);
+  const [input, setInput] = useState<string>('');
+  const [namespace, setNamespace] = useState('');
 
-	// Submit once all values are acceptable
-	useEffect(() => {
-		const hasUMD = format.includes('umd');
+  // Submit once all values are acceptable
+  useEffect(() => {
+    const hasUMD = format.includes('umd');
 
-		if (
-			platform.length > 0 &&
-			format.length > 0 &&
-			support &&
-			input &&
-			((hasUMD && namespace) || (!hasUMD && !namespace))
-		) {
-			const result = {
-				format,
-				inputs: { index: input },
-				namespace,
-				platform,
-				support,
-			};
+    if (
+      platform.length > 0 &&
+      format.length > 0 &&
+      support &&
+      input &&
+      ((hasUMD && namespace) || (!hasUMD && !namespace))
+    ) {
+      const result = {
+        format,
+        inputs: { index: input },
+        namespace,
+        platform,
+        support,
+      };
 
-			// Delay submission or focus API crashes
-			// https://github.com/vadimdemedes/ink/pull/404
-			setTimeout(() => {
-				onSubmit(result);
-			}, 100);
+      // Delay submission or focus API crashes
+      // https://github.com/vadimdemedes/ink/pull/404
+      setTimeout(() => {
+        onSubmit(result);
+      }, 100);
 
-			// Reset state for the next package
-			setPlatform([]);
-			setSupport(DEFAULT_SUPPORT);
-			setFormat([]);
-			setInput('');
-			setNamespace('');
-		}
-	}, [format, input, namespace, onSubmit, platform, support]);
+      // Reset state for the next package
+      setPlatform([]);
+      setSupport(DEFAULT_SUPPORT);
+      setFormat([]);
+      setInput('');
+      setNamespace('');
+    }
+  }, [format, input, namespace, onSubmit, platform, support]);
 
-	// PLATFORM
+  // PLATFORM
 
-	const platformOptions = useMemo<SelectOptionLike<Platform>[]>(
-		() => [
-			{ label: 'Browsers', value: 'browser' },
-			{ label: 'Node', value: 'node' },
-			{ label: 'React Native', value: 'native' },
-		],
-		[],
-	);
+  const platformOptions = useMemo<SelectOptionLike<Platform>[]>(
+    () => [
+      { label: 'Browsers', value: 'browser' },
+      { label: 'Node', value: 'node' },
+      { label: 'React Native', value: 'native' },
+    ],
+    [],
+  );
 
-	const validatePlatform = useCallback((value: Platform[]) => {
-		if (value.length === 0) {
-			throw new Error('Please select at least 1 platform');
-		}
-	}, []);
+  const validatePlatform = useCallback((value: Platform[]) => {
+    if (value.length === 0) {
+      throw new Error('Please select at least 1 platform');
+    }
+  }, []);
 
-	// SUPPORT
+  // SUPPORT
 
-	const supportOptions = useMemo<SelectOptionLike<Support>[]>(
-		() => [
-			{
-				label: `Legacy ${getSupportVersions(platform, 'legacy')}`,
-				value: 'legacy',
-			},
-			{
-				label: `Stable ${getSupportVersions(platform, 'stable')}`,
-				value: 'stable',
-			},
-			{
-				label: `Current ${getSupportVersions(platform, 'current')}`,
-				value: 'current',
-			},
-			{
-				label: `Experimental ${getSupportVersions(platform, 'experimental')}`,
-				value: 'experimental',
-			},
-		],
-		[platform],
-	);
+  const supportOptions = useMemo<SelectOptionLike<Support>[]>(
+    () => [
+      {
+        label: `Legacy ${getSupportVersions(platform, 'legacy')}`,
+        value: 'legacy',
+      },
+      {
+        label: `Stable ${getSupportVersions(platform, 'stable')}`,
+        value: 'stable',
+      },
+      {
+        label: `Current ${getSupportVersions(platform, 'current')}`,
+        value: 'current',
+      },
+      {
+        label: `Experimental ${getSupportVersions(platform, 'experimental')}`,
+        value: 'experimental',
+      },
+    ],
+    [platform],
+  );
 
-	const validateSupport = useCallback((value: Support) => {
-		if (!value) {
-			throw new Error('Please select a supported environment');
-		}
-	}, []);
+  const validateSupport = useCallback((value: Support) => {
+    if (!value) {
+      throw new Error('Please select a supported environment');
+    }
+  }, []);
 
-	// FORMAT
+  // FORMAT
 
-	const formatOptions = useMemo(() => {
-		const options: SelectOptionLike<Format>[] = [{ label: 'Shared CommonJS', value: 'lib' }];
+  const formatOptions = useMemo(() => {
+    const options: SelectOptionLike<Format>[] = [{ label: 'Shared CommonJS', value: 'lib' }];
 
-		if (platform.includes('node')) {
-			options.push(
-				{ label: `Node - CommonJS ${applyStyle('(.cjs)', 'muted')}`, value: 'cjs' },
-				{ label: `Node - ECMAScript ${applyStyle('(.mjs)', 'muted')}`, value: 'mjs' },
-			);
-		}
+    if (platform.includes('node')) {
+      options.push(
+        { label: `Node - CommonJS ${applyStyle('(.cjs)', 'muted')}`, value: 'cjs' },
+        { label: `Node - ECMAScript ${applyStyle('(.mjs)', 'muted')}`, value: 'mjs' },
+      );
+    }
 
-		if (platform.includes('browser')) {
-			options.push(
-				{ label: 'Browser - ECMAScript', value: 'esm' },
-				{ label: 'Browser - UMD', value: 'umd' },
-			);
-		}
+    if (platform.includes('browser')) {
+      options.push(
+        { label: 'Browser - ECMAScript', value: 'esm' },
+        { label: 'Browser - UMD', value: 'umd' },
+      );
+    }
 
-		return options;
-	}, [platform]);
+    return options;
+  }, [platform]);
 
-	const validateFormat = useCallback((value: Format[]) => {
-		if (value.length === 0) {
-			throw new Error('Please select at least 1 format');
-		}
-	}, []);
+  const validateFormat = useCallback((value: Format[]) => {
+    if (value.length === 0) {
+      throw new Error('Please select at least 1 format');
+    }
+  }, []);
 
-	// INPUT
+  // INPUT
 
-	const validateInput = useCallback((value: string) => {
-		if (!value || !value.match(/[-_a-z\d./\\]+/iu)) {
-			throw new Error('Must be a valid file path');
-		}
-	}, []);
+  const validateInput = useCallback((value: string) => {
+    if (!value || !value.match(/[-_a-z\d./\\]+/iu)) {
+      throw new Error('Must be a valid file path');
+    }
+  }, []);
 
-	// NAMESPACE
+  // NAMESPACE
 
-	const validateNamespace = useCallback((value: string) => {
-		if (!value || !value.match(/[a-z]\w+/iu)) {
-			throw new Error('Must be in pascal-case or camel-case and start with an alpha character');
-		}
-	}, []);
+  const validateNamespace = useCallback((value: string) => {
+    if (!value || !value.match(/[a-z]\w+/iu)) {
+      throw new Error('Must be in pascal-case or camel-case and start with an alpha character');
+    }
+  }, []);
 
-	return (
-		<>
-			<MultiSelect<Platform>
-				label="Platforms to target?"
-				options={platformOptions}
-				validate={validatePlatform}
-				onSubmit={setPlatform}
-			/>
+  return (
+    <>
+      <MultiSelect<Platform>
+        label="Platforms to target?"
+        options={platformOptions}
+        validate={validatePlatform}
+        onSubmit={setPlatform}
+      />
 
-			<Select<Support>
-				defaultSelected={DEFAULT_SUPPORT}
-				label="Environment to support?"
-				options={supportOptions}
-				validate={validateSupport}
-				onSubmit={setSupport}
-			/>
+      <Select<Support>
+        defaultSelected={DEFAULT_SUPPORT}
+        label="Environment to support?"
+        options={supportOptions}
+        validate={validateSupport}
+        onSubmit={setSupport}
+      />
 
-			<MultiSelect<Format>
-				defaultSelected={FORMAT_LIST}
-				label="Formats to build?"
-				options={formatOptions}
-				validate={validateFormat}
-				onSubmit={setFormat}
-			/>
+      <MultiSelect<Format>
+        defaultSelected={FORMAT_LIST}
+        label="Formats to build?"
+        options={formatOptions}
+        validate={validateFormat}
+        onSubmit={setFormat}
+      />
 
-			<Input
-				defaultValue={DEFAULT_INPUT}
-				label="Main entry point?"
-				validate={validateInput}
-				onSubmit={setInput}
-			/>
+      <Input
+        defaultValue={DEFAULT_INPUT}
+        label="Main entry point?"
+        validate={validateInput}
+        onSubmit={setInput}
+      />
 
-			{format.includes('umd') && (
-				<Input label="UMD namespace?" validate={validateNamespace} onSubmit={setNamespace} />
-			)}
-		</>
-	);
+      {format.includes('umd') && (
+        <Input label="UMD namespace?" validate={validateNamespace} onSubmit={setNamespace} />
+      )}
+    </>
+  );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,69 +1,69 @@
 import { StyleType } from '@boost/cli';
 import {
-	ArtifactState,
-	BrowserFormat,
-	Format,
-	NativeFormat,
-	NodeFormat,
-	Platform,
-	Support,
+  ArtifactState,
+  BrowserFormat,
+  Format,
+  NativeFormat,
+  NodeFormat,
+  Platform,
+  Support,
 } from './types';
 
 export const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'];
 
 export const EXCLUDE = [
-	'node_modules/**',
-	'tests/**',
-	'__fixtures__/**',
-	'__mocks__/**',
-	'__tests__/**',
-	'*.config.(c|m)?js',
-	'*.(test|spec).(js|ts)x?',
+  'node_modules/**',
+  'tests/**',
+  '__fixtures__/**',
+  '__mocks__/**',
+  '__tests__/**',
+  '*.config.(c|m)?js',
+  '*.(test|spec).(js|ts)x?',
 ];
 
 // https://reactnative.dev/docs/javascript-environment
 // Based on browserslist: https://github.com/browserslist/browserslist
 export const NATIVE_TARGETS: { [K in Support]: string } = {
-	legacy: 'iOS 8',
-	stable: 'iOS 10',
-	current: 'iOS 12',
-	experimental: 'iOS 14',
+  legacy: 'iOS 8',
+  stable: 'iOS 10',
+  current: 'iOS 12',
+  experimental: 'iOS 14',
 };
 
 // Based on LTS schedule: https://nodejs.org/en/about/releases/
 export const NODE_SUPPORTED_VERSIONS: { [K in Support]: string } = {
-	legacy: '10.3.0',
-	stable: '12.17.0', // ESM support not behind a flag
-	current: '14.16.0', // Includes security fixes
-	experimental: '16.0.0',
+  legacy: '10.3.0',
+  stable: '12.17.0', // ESM support not behind a flag
+  current: '14.16.0', // Includes security fixes
+  experimental: '16.0.0',
 };
 
 export const NPM_SUPPORTED_VERSIONS: { [K in Support]: string[] | string } = {
-	legacy: '6.1.0',
-	stable: '6.13.0',
-	current: ['6.14.0', '7.0.0'],
-	experimental: '7.0.0',
+  legacy: '6.1.0',
+  stable: '6.13.0',
+  current: ['6.14.0', '7.0.0'],
+  experimental: '7.0.0',
 };
 
 // Based on browserslist: https://github.com/browserslist/browserslist
 export const BROWSER_TARGETS: { [K in Support]: string[] | string } = {
-	legacy: 'IE 11',
-	stable: ['defaults', 'not IE 11'],
-	current: ['> 1%', 'not dead'],
-	experimental: ['last 2 chrome versions', 'last 2 firefox versions'],
+  legacy: 'IE 11',
+  stable: ['defaults', 'not IE 11'],
+  current: ['> 1%', 'not dead'],
+  experimental: ['last 2 chrome versions', 'last 2 firefox versions'],
 };
 
 export const STATE_COLORS: { [K in ArtifactState]?: StyleType } = {
-	pending: 'muted',
-	passed: 'success',
-	failed: 'failure',
+  pending: 'muted',
+  passed: 'success',
+  failed: 'failure',
 };
 
 export const STATE_LABELS: { [K in ArtifactState]: string } = {
-	pending: '',
-	building: 'Building',
-	passed: 'Passed',
-	failed: 'Failed',
+  pending: '',
+  building: 'Building',
+  passed: 'Passed',
+  failed: 'Failed',
 };
 
 export const FORMATS_BROWSER: BrowserFormat[] = ['lib', 'esm', 'umd'];
@@ -85,8 +85,8 @@ export const DEFAULT_SUPPORT: Support = 'stable';
 export const SUPPORTS: Support[] = ['legacy', 'stable', 'current', 'experimental'];
 
 export const SUPPORT_PRIORITY: Record<Support, number> = {
-	legacy: 0,
-	stable: 1,
-	current: 2,
-	experimental: 3,
+  legacy: 0,
+  stable: 1,
+  current: 2,
+  experimental: 3,
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,72 +1,70 @@
 import { StyleType } from '@boost/cli';
 import {
-  ArtifactState,
-  BrowserFormat,
-  Format,
-  NativeFormat,
-  NodeFormat,
-  Platform,
-  Support,
+	ArtifactState,
+	BrowserFormat,
+	Format,
+	NativeFormat,
+	NodeFormat,
+	Platform,
+	Support,
 } from './types';
 
 export const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.cjs', '.mjs'];
 
 export const EXCLUDE = [
-  'node_modules/**',
-  'tests/**',
-  '__fixtures__/**',
-  '__mocks__/**',
-  '__tests__/**',
-  '*.config.(c|m)?js',
-  '*.(test|spec).(js|ts)x?',
+	'node_modules/**',
+	'tests/**',
+	'__fixtures__/**',
+	'__mocks__/**',
+	'__tests__/**',
+	'*.config.(c|m)?js',
+	'*.(test|spec).(js|ts)x?',
 ];
 
 // https://reactnative.dev/docs/javascript-environment
 // Based on browserslist: https://github.com/browserslist/browserslist
 export const NATIVE_TARGETS: { [K in Support]: string } = {
-  legacy: 'iOS 8',
-  stable: 'iOS 10',
-  current: 'iOS 12',
-  experimental: 'iOS 14',
+	legacy: 'iOS 8',
+	stable: 'iOS 10',
+	current: 'iOS 12',
+	experimental: 'iOS 14',
 };
 
 // Based on LTS schedule: https://nodejs.org/en/about/releases/
 export const NODE_SUPPORTED_VERSIONS: { [K in Support]: string } = {
-  legacy: '10.3.0',
-  stable: '12.17.0', // ESM support not behind a flag
-  current: '14.16.0', // Includes security fixes
-  experimental: '16.0.0',
+	legacy: '10.3.0',
+	stable: '12.17.0', // ESM support not behind a flag
+	current: '14.16.0', // Includes security fixes
+	experimental: '16.0.0',
 };
 
 export const NPM_SUPPORTED_VERSIONS: { [K in Support]: string[] | string } = {
-  legacy: '6.1.0',
-  stable: '6.13.0',
-  current: ['6.14.0', '7.0.0'],
-  experimental: '7.0.0',
+	legacy: '6.1.0',
+	stable: '6.13.0',
+	current: ['6.14.0', '7.0.0'],
+	experimental: '7.0.0',
 };
 
 // Based on browserslist: https://github.com/browserslist/browserslist
 export const BROWSER_TARGETS: { [K in Support]: string[] | string } = {
-  legacy: 'IE 11',
-  stable: ['defaults', 'not IE 11'],
-  current: ['> 1%', 'not dead'],
-  experimental: ['last 2 chrome versions', 'last 2 firefox versions'],
+	legacy: 'IE 11',
+	stable: ['defaults', 'not IE 11'],
+	current: ['> 1%', 'not dead'],
+	experimental: ['last 2 chrome versions', 'last 2 firefox versions'],
 };
 
 export const STATE_COLORS: { [K in ArtifactState]?: StyleType } = {
-  pending: 'muted',
-  passed: 'success',
-  failed: 'failure',
+	pending: 'muted',
+	passed: 'success',
+	failed: 'failure',
 };
 
 export const STATE_LABELS: { [K in ArtifactState]: string } = {
-  pending: '',
-  building: 'Building',
-  passed: 'Passed',
-  failed: 'Failed',
+	pending: '',
+	building: 'Building',
+	passed: 'Passed',
+	failed: 'Failed',
 };
-
-export const DEFAULT_FORMAT: Format = 'lib';
 
 export const FORMATS_BROWSER: BrowserFormat[] = ['lib', 'esm', 'umd'];
 
@@ -87,8 +85,8 @@ export const DEFAULT_SUPPORT: Support = 'stable';
 export const SUPPORTS: Support[] = ['legacy', 'stable', 'current', 'experimental'];
 
 export const SUPPORT_PRIORITY: Record<Support, number> = {
-  legacy: 0,
-  stable: 1,
-  current: 2,
-  experimental: 3,
+	legacy: 0,
+	stable: 1,
+	current: 2,
+	experimental: 3,
 };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,27 +1,27 @@
 import { Blueprint, predicates, toArray } from '@boost/common';
 import {
-	DEFAULT_INPUT,
-	DEFAULT_PLATFORM,
-	DEFAULT_SUPPORT,
-	FORMATS,
-	FORMATS_BROWSER,
-	FORMATS_NATIVE,
-	FORMATS_NODE,
-	PLATFORMS,
-	SUPPORTS,
+  DEFAULT_INPUT,
+  DEFAULT_PLATFORM,
+  DEFAULT_SUPPORT,
+  FORMATS,
+  FORMATS_BROWSER,
+  FORMATS_NATIVE,
+  FORMATS_NODE,
+  PLATFORMS,
+  SUPPORTS,
 } from './constants';
 import {
-	AnalyzeType,
-	BrowserFormat,
-	BuildOptions,
-	DeclarationType,
-	Format,
-	NativeFormat,
-	NodeFormat,
-	PackemonPackageConfig,
-	Platform,
-	Support,
-	ValidateOptions,
+  AnalyzeType,
+  BrowserFormat,
+  BuildOptions,
+  DeclarationType,
+  Format,
+  NativeFormat,
+  NodeFormat,
+  PackemonPackageConfig,
+  Platform,
+  Support,
+  ValidateOptions,
 } from './types';
 
 const { array, bool, number, object, string, union } = predicates;
@@ -37,18 +37,18 @@ const nodeFormat = string<NodeFormat>('mjs').oneOf(FORMATS_NODE);
 const browserFormat = string<BrowserFormat>('esm').oneOf(FORMATS_BROWSER);
 
 const format = string<Format>('lib')
-	.oneOf(FORMATS)
-	.custom<PackemonPackageConfig>((value, schema) => {
-		const platforms = new Set(toArray(schema.struct.platform));
+  .oneOf(FORMATS)
+  .custom<PackemonPackageConfig>((value, schema) => {
+    const platforms = new Set(toArray(schema.struct.platform));
 
-		if (platforms.has('browser') && platforms.size === 1) {
-			browserFormat.validate(value as BrowserFormat, schema.currentPath);
-		} else if (platforms.has('native') && platforms.size === 1) {
-			nativeFormat.validate(value as NativeFormat, schema.currentPath);
-		} else if (platforms.has('node') && platforms.size === 1) {
-			nodeFormat.validate(value as NodeFormat, schema.currentPath);
-		}
-	});
+    if (platforms.has('browser') && platforms.size === 1) {
+      browserFormat.validate(value as BrowserFormat, schema.currentPath);
+    } else if (platforms.has('native') && platforms.size === 1) {
+      nativeFormat.validate(value as NativeFormat, schema.currentPath);
+    } else if (platforms.has('node') && platforms.size === 1) {
+      nodeFormat.validate(value as NodeFormat, schema.currentPath);
+    }
+  });
 
 // SUPPORT
 
@@ -57,43 +57,43 @@ const support = string<Support>(DEFAULT_SUPPORT).oneOf(SUPPORTS);
 // BLUEPRINTS
 
 export const packemonBlueprint: Blueprint<PackemonPackageConfig> = {
-	bundle: bool(true),
-	format: union([array(format), format], []),
-	inputs: object(string(), { index: DEFAULT_INPUT }).custom((obj) => {
-		Object.keys(obj).forEach((key) => {
-			if (!key.match(/^\w+$/u)) {
-				throw new Error(`Input "${key}" may only contain alpha-numeric characters.`);
-			}
-		});
-	}),
-	namespace: string(),
-	platform: union([array(platform), platform], DEFAULT_PLATFORM),
-	support,
+  bundle: bool(true),
+  format: union([array(format), format], []),
+  inputs: object(string(), { index: DEFAULT_INPUT }).custom((obj) => {
+    Object.keys(obj).forEach((key) => {
+      if (!key.match(/^\w+$/u)) {
+        throw new Error(`Input "${key}" may only contain alpha-numeric characters.`);
+      }
+    });
+  }),
+  namespace: string(),
+  platform: union([array(platform), platform], DEFAULT_PLATFORM),
+  support,
 };
 
 export const buildBlueprint: Blueprint<BuildOptions> = {
-	addEngines: bool(),
-	addExports: bool(),
-	analyze: string('none').oneOf<AnalyzeType>(['none', 'sunburst', 'treemap', 'network']),
-	concurrency: number(1).gte(1),
-	declaration: string('none').oneOf<DeclarationType>(['none', 'standard', 'api']),
-	declarationConfig: string(),
-	filter: string(),
-	filterFormats: string(),
-	filterPlatforms: string(),
-	skipPrivate: bool(),
-	timeout: number().gte(0),
+  addEngines: bool(),
+  addExports: bool(),
+  analyze: string('none').oneOf<AnalyzeType>(['none', 'sunburst', 'treemap', 'network']),
+  concurrency: number(1).gte(1),
+  declaration: string('none').oneOf<DeclarationType>(['none', 'standard', 'api']),
+  declarationConfig: string(),
+  filter: string(),
+  filterFormats: string(),
+  filterPlatforms: string(),
+  skipPrivate: bool(),
+  timeout: number().gte(0),
 };
 
 export const validateBlueprint: Blueprint<ValidateOptions> = {
-	deps: bool(true),
-	engines: bool(true),
-	entries: bool(true),
-	files: bool(true),
-	license: bool(true),
-	links: bool(true),
-	meta: bool(true),
-	people: bool(true),
-	skipPrivate: bool(false),
-	repo: bool(true),
+  deps: bool(true),
+  engines: bool(true),
+  entries: bool(true),
+  files: bool(true),
+  license: bool(true),
+  links: bool(true),
+  meta: bool(true),
+  people: bool(true),
+  skipPrivate: bool(false),
+  repo: bool(true),
 };

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,28 +1,27 @@
 import { Blueprint, predicates, toArray } from '@boost/common';
 import {
-  DEFAULT_FORMAT,
-  DEFAULT_INPUT,
-  DEFAULT_PLATFORM,
-  DEFAULT_SUPPORT,
-  FORMATS,
-  FORMATS_BROWSER,
-  FORMATS_NATIVE,
-  FORMATS_NODE,
-  PLATFORMS,
-  SUPPORTS,
+	DEFAULT_INPUT,
+	DEFAULT_PLATFORM,
+	DEFAULT_SUPPORT,
+	FORMATS,
+	FORMATS_BROWSER,
+	FORMATS_NATIVE,
+	FORMATS_NODE,
+	PLATFORMS,
+	SUPPORTS,
 } from './constants';
 import {
-  AnalyzeType,
-  BrowserFormat,
-  BuildOptions,
-  DeclarationType,
-  Format,
-  NativeFormat,
-  NodeFormat,
-  PackemonPackageConfig,
-  Platform,
-  Support,
-  ValidateOptions,
+	AnalyzeType,
+	BrowserFormat,
+	BuildOptions,
+	DeclarationType,
+	Format,
+	NativeFormat,
+	NodeFormat,
+	PackemonPackageConfig,
+	Platform,
+	Support,
+	ValidateOptions,
 } from './types';
 
 const { array, bool, number, object, string, union } = predicates;
@@ -33,23 +32,23 @@ const platform = string<Platform>(DEFAULT_PLATFORM).oneOf(PLATFORMS);
 
 // FORMATS
 
-const nativeFormat = string<NativeFormat>(DEFAULT_FORMAT).oneOf(FORMATS_NATIVE);
-const nodeFormat = string<NodeFormat>(DEFAULT_FORMAT).oneOf(FORMATS_NODE);
-const browserFormat = string<BrowserFormat>(DEFAULT_FORMAT).oneOf(FORMATS_BROWSER);
+const nativeFormat = string<NativeFormat>('lib').oneOf(FORMATS_NATIVE);
+const nodeFormat = string<NodeFormat>('mjs').oneOf(FORMATS_NODE);
+const browserFormat = string<BrowserFormat>('esm').oneOf(FORMATS_BROWSER);
 
-const format = string<Format>(DEFAULT_FORMAT)
-  .oneOf(FORMATS)
-  .custom<PackemonPackageConfig>((value, schema) => {
-    const platforms = new Set(toArray(schema.struct.platform));
+const format = string<Format>('lib')
+	.oneOf(FORMATS)
+	.custom<PackemonPackageConfig>((value, schema) => {
+		const platforms = new Set(toArray(schema.struct.platform));
 
-    if (platforms.has('browser') && platforms.size === 1) {
-      browserFormat.validate(value as BrowserFormat, schema.currentPath);
-    } else if (platforms.has('native') && platforms.size === 1) {
-      nativeFormat.validate(value as NativeFormat, schema.currentPath);
-    } else if (platforms.has('node') && platforms.size === 1) {
-      nodeFormat.validate(value as NodeFormat, schema.currentPath);
-    }
-  });
+		if (platforms.has('browser') && platforms.size === 1) {
+			browserFormat.validate(value as BrowserFormat, schema.currentPath);
+		} else if (platforms.has('native') && platforms.size === 1) {
+			nativeFormat.validate(value as NativeFormat, schema.currentPath);
+		} else if (platforms.has('node') && platforms.size === 1) {
+			nodeFormat.validate(value as NodeFormat, schema.currentPath);
+		}
+	});
 
 // SUPPORT
 
@@ -58,43 +57,43 @@ const support = string<Support>(DEFAULT_SUPPORT).oneOf(SUPPORTS);
 // BLUEPRINTS
 
 export const packemonBlueprint: Blueprint<PackemonPackageConfig> = {
-  bundle: bool(true),
-  format: union([array(format), format], []),
-  inputs: object(string(), { index: DEFAULT_INPUT }).custom((obj) => {
-    Object.keys(obj).forEach((key) => {
-      if (!key.match(/^\w+$/u)) {
-        throw new Error(`Input "${key}" may only contain alpha-numeric characters.`);
-      }
-    });
-  }),
-  namespace: string(),
-  platform: union([array(platform), platform], DEFAULT_PLATFORM),
-  support,
+	bundle: bool(true),
+	format: union([array(format), format], []),
+	inputs: object(string(), { index: DEFAULT_INPUT }).custom((obj) => {
+		Object.keys(obj).forEach((key) => {
+			if (!key.match(/^\w+$/u)) {
+				throw new Error(`Input "${key}" may only contain alpha-numeric characters.`);
+			}
+		});
+	}),
+	namespace: string(),
+	platform: union([array(platform), platform], DEFAULT_PLATFORM),
+	support,
 };
 
 export const buildBlueprint: Blueprint<BuildOptions> = {
-  addEngines: bool(),
-  addExports: bool(),
-  analyze: string('none').oneOf<AnalyzeType>(['none', 'sunburst', 'treemap', 'network']),
-  concurrency: number(1).gte(1),
-  declaration: string('none').oneOf<DeclarationType>(['none', 'standard', 'api']),
-  declarationConfig: string(),
-  filter: string(),
-  filterFormats: string(),
-  filterPlatforms: string(),
-  skipPrivate: bool(),
-  timeout: number().gte(0),
+	addEngines: bool(),
+	addExports: bool(),
+	analyze: string('none').oneOf<AnalyzeType>(['none', 'sunburst', 'treemap', 'network']),
+	concurrency: number(1).gte(1),
+	declaration: string('none').oneOf<DeclarationType>(['none', 'standard', 'api']),
+	declarationConfig: string(),
+	filter: string(),
+	filterFormats: string(),
+	filterPlatforms: string(),
+	skipPrivate: bool(),
+	timeout: number().gte(0),
 };
 
 export const validateBlueprint: Blueprint<ValidateOptions> = {
-  deps: bool(true),
-  engines: bool(true),
-  entries: bool(true),
-  files: bool(true),
-  license: bool(true),
-  links: bool(true),
-  meta: bool(true),
-  people: bool(true),
-  skipPrivate: bool(false),
-  repo: bool(true),
+	deps: bool(true),
+	engines: bool(true),
+	entries: bool(true),
+	files: bool(true),
+	license: bool(true),
+	links: bool(true),
+	meta: bool(true),
+	people: bool(true),
+	skipPrivate: bool(false),
+	repo: bool(true),
 };

--- a/tests/Package.test.ts
+++ b/tests/Package.test.ts
@@ -1043,7 +1043,7 @@ describe('Package', () => {
       expect(pkg.configs).toEqual([
         {
           bundle: true,
-          formats: ['lib', 'esm'],
+          formats: ['esm'],
           inputs: {},
           platform: 'browser',
           namespace: '',
@@ -1066,7 +1066,7 @@ describe('Package', () => {
       expect(pkg.configs).toEqual([
         {
           bundle: true,
-          formats: ['lib', 'esm', 'umd'],
+          formats: ['esm', 'umd'],
           inputs: {},
           platform: 'browser',
           namespace: 'test',
@@ -1112,7 +1112,7 @@ describe('Package', () => {
       expect(pkg.configs).toEqual([
         {
           bundle: false,
-          formats: ['lib'],
+          formats: ['mjs'],
           inputs: {},
           platform: 'node',
           namespace: '',
@@ -1155,7 +1155,7 @@ describe('Package', () => {
       expect(pkg.configs).toEqual([
         {
           bundle: true,
-          formats: ['lib', 'esm'],
+          formats: ['esm'],
           inputs: {},
           platform: 'browser',
           namespace: '',
@@ -1163,7 +1163,7 @@ describe('Package', () => {
         },
         {
           bundle: false,
-          formats: ['lib'],
+          formats: ['mjs'],
           inputs: {},
           platform: 'node',
           namespace: '',
@@ -1224,7 +1224,7 @@ describe('Package', () => {
       expect(pkg.configs).toEqual([
         {
           bundle: true,
-          formats: ['lib'],
+          formats: ['mjs'],
           inputs: { index: 'src/index.ts' },
           platform: 'node',
           namespace: '',
@@ -1232,7 +1232,7 @@ describe('Package', () => {
         },
         {
           bundle: false,
-          formats: ['lib', 'esm'],
+          formats: ['esm'],
           inputs: { index: 'src/index.ts' },
           platform: 'browser',
           namespace: '',

--- a/tests/Packemon.test.ts
+++ b/tests/Packemon.test.ts
@@ -338,15 +338,11 @@ describe('Packemon', () => {
 
       expect(packages[1].artifacts).toHaveLength(1);
       expect((packages[1].artifacts[0] as CodeArtifact).inputs).toEqual({ core: './src/core.ts' });
-      expect(packages[1].artifacts[0].builds).toEqual([{ format: 'lib' }]);
+      expect(packages[1].artifacts[0].builds).toEqual([{ format: 'mjs' }]);
 
       expect(packages[2].artifacts).toHaveLength(1);
       expect((packages[2].artifacts[0] as CodeArtifact).inputs).toEqual({ index: 'src/index.ts' });
-      expect(packages[2].artifacts[0].builds).toEqual([
-        { format: 'lib' },
-        { format: 'esm' },
-        { format: 'umd' },
-      ]);
+      expect(packages[2].artifacts[0].builds).toEqual([{ format: 'esm' }, { format: 'umd' }]);
     });
 
     it('generates "standard" type artifacts for each config in a package', async () => {
@@ -422,8 +418,8 @@ describe('Packemon', () => {
 
       packemon.generateArtifacts(packages);
 
-      expect(packages[0].artifacts[0].builds).toEqual([{ format: 'lib' }, { format: 'esm' }]);
-      expect(packages[0].artifacts[1].builds).toEqual([{ format: 'lib' }]);
+      expect(packages[0].artifacts[0].builds).toEqual([{ format: 'esm' }]);
+      expect(packages[0].artifacts[1].builds).toEqual([{ format: 'mjs' }]);
     });
 
     it('filters formats using `filterFormats`', async () => {
@@ -448,7 +444,7 @@ describe('Packemon', () => {
         filterPlatforms: 'node',
       });
 
-      expect(packages[0].artifacts[0].builds).toEqual([{ format: 'lib' }]);
+      expect(packages[0].artifacts[0].builds).toEqual([{ format: 'mjs' }]);
       expect(packages[0].artifacts[1]).toBeUndefined();
     });
   });
@@ -500,7 +496,7 @@ describe('Packemon', () => {
       expect(two.configs).toEqual([
         {
           bundle: false,
-          formats: ['lib'],
+          formats: ['mjs'],
           inputs: { core: './src/core.ts' },
           namespace: '',
           platform: 'node',
@@ -512,7 +508,7 @@ describe('Packemon', () => {
       expect(three.configs).toEqual([
         {
           bundle: true,
-          formats: ['lib', 'esm', 'umd'],
+          formats: ['esm', 'umd'],
           inputs: { index: 'src/index.ts' },
           namespace: 'Test',
           platform: 'browser',

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -100,10 +100,12 @@ The supported environments above map to the following platform targets.
 The output format for each platform build target. Each format will create a folder relative to the
 project root that will house the built files.
 
+> Packemon defaults to an ECMAScript format if available.
+
 ### Browser
 
-- `lib` _(default)_ - [CommonJS](https://nodejs.org/api/modules.html) output using `.js` file
-  extension. For standard JavaScript and TypeScript projects.
+- `lib` - [CommonJS](https://nodejs.org/api/modules.html) output using `.js` file extension. For
+  standard JavaScript and TypeScript projects.
 - `esm` _(default)_ - ECMAScript module output using `.js` file extension. The same as `lib`, but
   uses `import/export` instead of `require`.
 - `umd` - Universal Module Definition output using `.js` file extension. Meant to be used directly
@@ -118,12 +120,13 @@ project root that will house the built files.
 
 ### Node
 
-- `lib` _(default)_ - [CommonJS](https://nodejs.org/api/modules.html) output using `.js` file
-  extension. For standard JavaScript and TypeScript projects.
+- `lib` - [CommonJS](https://nodejs.org/api/modules.html) output using `.js` file extension. For
+  standard JavaScript and TypeScript projects.
 - `cjs` - [CommonJS](https://nodejs.org/api/modules.html) output using `.cjs` file extension. Source
   files must be written in CommonJS (`.cjs`) and `require` paths must use trailing extensions.
-- `mjs` - [ECMAScript module](https://nodejs.org/api/esm.html) output using `.mjs` file extension.
-  Source files must be written in ESM (`.mjs`) and `import` paths must use trailing extensions.
+- `mjs` _(default)_ - [ECMAScript module](https://nodejs.org/api/esm.html) output using `.mjs` file
+  extension. Source files must be written in ESM (`.mjs`) and `import` paths must use trailing
+  extensions.
 
 ```json
 {


### PR DESCRIPTION
I want to encourage the use of ECMAScript modules, so Node will now default to `mjs`, and browsers to `esm`.