### PR TITLE
fix: Bring back `lib` as a browser default format.

### DIFF
--- a/src/Package.ts
+++ b/src/Package.ts
@@ -234,7 +234,7 @@ export class Package {
 					case 'browser':
 					default:
 						if (isEmpty) {
-							formats.push('esm');
+							formats.push('lib', 'esm');
 
 							if (config.namespace) {
 								formats.push('umd');

--- a/src/Package.ts
+++ b/src/Package.ts
@@ -7,6 +7,7 @@ import { createDebugger, Debugger } from '@boost/debug';
 import { Artifact } from './Artifact';
 import { CodeArtifact } from './CodeArtifact';
 import {
+	DEFAULT_FORMATS,
 	FORMATS_BROWSER,
 	FORMATS_NATIVE,
 	FORMATS_NODE,
@@ -213,7 +214,7 @@ export class Package {
 				switch (platform) {
 					case 'native':
 						if (isEmpty) {
-							formats.push('lib');
+							formats.push(...DEFAULT_FORMATS.native);
 						} else {
 							formats = formats.filter((format) => (FORMATS_NATIVE as string[]).includes(format));
 						}
@@ -225,7 +226,7 @@ export class Package {
 						}
 
 						if (isEmpty) {
-							formats.push('mjs');
+							formats.push(...DEFAULT_FORMATS.node);
 						} else {
 							formats = formats.filter((format) => (FORMATS_NODE as string[]).includes(format));
 						}
@@ -234,7 +235,7 @@ export class Package {
 					case 'browser':
 					default:
 						if (isEmpty) {
-							formats.push('lib', 'esm');
+							formats.push(...DEFAULT_FORMATS.browser);
 
 							if (config.namespace) {
 								formats.push('umd');

--- a/src/components/Init/PackageForm.tsx
+++ b/src/components/Init/PackageForm.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { applyStyle, Input, MultiSelect, Select, SelectOptionLike } from '@boost/cli';
-import { DEFAULT_INPUT, DEFAULT_SUPPORT } from '../../constants';
+import { DEFAULT_FORMATS, DEFAULT_INPUT, DEFAULT_SUPPORT } from '../../constants';
 import { Format, PackemonPackageConfig, Platform, Support } from '../../types';
 import { getVersionsCombo } from '../Environment';
 
@@ -11,12 +11,6 @@ export interface PackageFormProps {
 function getSupportVersions(platforms: Platform[], support: Support): string {
 	return applyStyle([...getVersionsCombo(platforms, support)].sort().join(', '), 'muted');
 }
-
-const DEFAULT_FORMATS: Record<Platform, Format[]> = {
-	browser: ['esm'],
-	native: ['lib'],
-	node: ['mjs'],
-};
 
 export function PackageForm({ onSubmit }: PackageFormProps) {
 	const [platform, setPlatform] = useState<Platform[]>([]);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -66,6 +66,12 @@ export const STATE_LABELS: { [K in ArtifactState]: string } = {
 	failed: 'Failed',
 };
 
+export const DEFAULT_FORMATS: Record<Platform, Format[]> = {
+	browser: ['lib', 'esm'],
+	native: ['lib'],
+	node: ['mjs'],
+};
+
 export const FORMATS_BROWSER: BrowserFormat[] = ['lib', 'esm', 'umd'];
 
 export const FORMATS_NATIVE: NativeFormat[] = ['lib'];

--- a/tests/Package.test.ts
+++ b/tests/Package.test.ts
@@ -1071,7 +1071,7 @@ describe('Package', () => {
 			expect(pkg.configs).toEqual([
 				{
 					bundle: true,
-					formats: ['esm'],
+					formats: ['lib', 'esm'],
 					inputs: {},
 					platform: 'browser',
 					namespace: '',
@@ -1094,7 +1094,7 @@ describe('Package', () => {
 			expect(pkg.configs).toEqual([
 				{
 					bundle: true,
-					formats: ['esm', 'umd'],
+					formats: ['lib', 'esm', 'umd'],
 					inputs: {},
 					platform: 'browser',
 					namespace: 'test',
@@ -1183,7 +1183,7 @@ describe('Package', () => {
 			expect(pkg.configs).toEqual([
 				{
 					bundle: true,
-					formats: ['esm'],
+					formats: ['lib', 'esm'],
 					inputs: {},
 					platform: 'browser',
 					namespace: '',
@@ -1260,7 +1260,7 @@ describe('Package', () => {
 				},
 				{
 					bundle: false,
-					formats: ['esm'],
+					formats: ['lib', 'esm'],
 					inputs: { index: 'src/index.ts' },
 					platform: 'browser',
 					namespace: '',

--- a/tests/Packemon.test.ts
+++ b/tests/Packemon.test.ts
@@ -342,7 +342,11 @@ describe('Packemon', () => {
 
 			expect(packages[2].artifacts).toHaveLength(1);
 			expect((packages[2].artifacts[0] as CodeArtifact).inputs).toEqual({ index: 'src/index.ts' });
-			expect(packages[2].artifacts[0].builds).toEqual([{ format: 'esm' }, { format: 'umd' }]);
+			expect(packages[2].artifacts[0].builds).toEqual([
+				{ format: 'lib' },
+				{ format: 'esm' },
+				{ format: 'umd' },
+			]);
 		});
 
 		it('generates "standard" type artifacts for each config in a package', async () => {
@@ -418,7 +422,7 @@ describe('Packemon', () => {
 
 			packemon.generateArtifacts(packages);
 
-			expect(packages[0].artifacts[0].builds).toEqual([{ format: 'esm' }]);
+			expect(packages[0].artifacts[0].builds).toEqual([{ format: 'lib' }, { format: 'esm' }]);
 			expect(packages[0].artifacts[1].builds).toEqual([{ format: 'mjs' }]);
 		});
 
@@ -508,7 +512,7 @@ describe('Packemon', () => {
 			expect(three.configs).toEqual([
 				{
 					bundle: true,
-					formats: ['esm', 'umd'],
+					formats: ['lib', 'esm', 'umd'],
 					inputs: { index: 'src/index.ts' },
 					namespace: 'Test',
 					platform: 'browser',

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -104,8 +104,8 @@ project root that will house the built files.
 
 ### Browser
 
-- `lib` - [CommonJS](https://nodejs.org/api/modules.html) output using `.js` file extension. For
-  standard JavaScript and TypeScript projects.
+- `lib` _(default)_ - [CommonJS](https://nodejs.org/api/modules.html) output using `.js` file
+  extension. For standard JavaScript and TypeScript projects.
 - `esm` _(default)_ - ECMAScript module output using `.js` file extension. The same as `lib`, but
   uses `import/export` instead of `require`.
 - `umd` - Universal Module Definition output using `.js` file extension. Meant to be used directly


### PR DESCRIPTION
While purely ESM would be nice, a lot of tools still don't support it well enough :[