### PR TITLE
docs: Add "declaration" to TypeScript integration.

### DIFF
--- a/website/docs/setup.mdx
+++ b/website/docs/setup.mdx
@@ -128,6 +128,7 @@ to `lib`, `build`, or some other variant. This is especially true if using proje
 ```json title="tsconfig.json"
 {
 	"compilerOptions": {
+		"declaration": true,
 		"declarationDir": "dts",
 		"outDir": "dts"
 	}
@@ -171,6 +172,7 @@ should be updated to only emit declarations to `dts`, like so.
 ```json title="tsconfig.json"
 {
 	"compilerOptions": {
+		"declaration": true,
 		"declarationDir": "dts",
 		"outDir": "dts",
 		"rootDir": "src",


### PR DESCRIPTION
TypeScript requires `declaration: true` when `declarationDir` is used.

For example, when we used next tsconf.json, tsc throw error.( `tsc --init` based and `declarationDir`)

```json
{
  "compilerOptions": {
    "declarationDir": "dts",
    "outDir": "dts",
    "target": "ES2018",
    "module": "ESNext",
    "esModuleInterop": true,
    "forceConsistentCasingInFileNames": true,
    "strict": true,
    "skipLibCheck": true
  }
}
```

We got following error.


```bash
$ tsc --noEmit
tsconfig.json:3:5 - error TS5069: Option 'declarationDir' cannot be specified without specifying option 'declaration' or option 'composite'.

3     "declarationDir": "dts",
      ~~~~~~~~~~~~~~~~


Found 1 error.
```