### PR TITLE
breaking: Remove `--analyze` option.

### DIFF
--- a/packages/packemon/package.json
+++ b/packages/packemon/package.json
@@ -89,7 +89,6 @@
     "rollup": "^2.70.1",
     "rollup-plugin-node-externals": "^2.2.0",
     "rollup-plugin-polyfill-node": "^0.8.0",
-    "rollup-plugin-visualizer": "^5.6.0",
     "semver": "^7.3.5",
     "spdx-license-list": "^6.4.0"
   },

--- a/packages/packemon/src/CodeArtifact.ts
+++ b/packages/packemon/src/CodeArtifact.ts
@@ -60,11 +60,6 @@ export class CodeArtifact extends Artifact<CodeBuild> {
 		this.debug('Building code artifacts with Rollup');
 
 		const features = this.package.getFeatureFlags();
-
-		if (options.analyze !== 'none') {
-			features.analyze = options.analyze;
-		}
-
 		const { output = [], ...input } = getRollupConfig(this, features, packemonConfig);
 		const bundle = await rollup({
 			...input,

--- a/packages/packemon/src/commands/Build.tsx
+++ b/packages/packemon/src/commands/Build.tsx
@@ -1,7 +1,7 @@
 import os from 'os';
 import React from 'react';
 import { Arg, Config } from '@boost/cli';
-import { AnalyzeType, BuildOptions } from '../types';
+import { BuildOptions } from '../types';
 import { BaseCommand } from './Base';
 
 @Config('build', 'Build standardized packages for distribution')
@@ -14,11 +14,6 @@ export class BuildCommand extends BaseCommand<Required<BuildOptions>> {
 
 	@Arg.Flag('Add `files` whitelist to each `package.json`')
 	addFiles: boolean = true;
-
-	@Arg.String('Visualize and analyze all generated builds', {
-		choices: ['none', 'sunburst', 'treemap', 'network'],
-	})
-	analyze: AnalyzeType = 'none';
 
 	@Arg.Number('Number of builds to run in parallel')
 	concurrency: number = os.cpus().length;
@@ -43,7 +38,6 @@ export class BuildCommand extends BaseCommand<Required<BuildOptions>> {
 				addEngines={this.addEngines}
 				addExports={this.addExports}
 				addFiles={this.addFiles}
-				analyze={this.analyze}
 				concurrency={this.concurrency}
 				declaration={this.declaration}
 				declarationConfig={this.declarationConfig}

--- a/packages/packemon/src/commands/Pack.tsx
+++ b/packages/packemon/src/commands/Pack.tsx
@@ -12,7 +12,6 @@ export class PackCommand extends BuildCommand {
 				addEngines={this.addEngines}
 				addExports={this.addExports}
 				addFiles={this.addFiles}
-				analyze={this.analyze}
 				concurrency={this.concurrency}
 				declaration={this.declaration}
 				declarationConfig={this.declarationConfig}

--- a/packages/packemon/src/rollup/config.ts
+++ b/packages/packemon/src/rollup/config.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { ModuleFormat, OutputOptions, RollupOptions } from 'rollup';
 import externals from 'rollup-plugin-node-externals';
 import nodePolyfills from 'rollup-plugin-polyfill-node';

--- a/packages/packemon/src/rollup/config.ts
+++ b/packages/packemon/src/rollup/config.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import { ModuleFormat, OutputOptions, RollupOptions } from 'rollup';
 import externals from 'rollup-plugin-node-externals';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
-import visualizer from 'rollup-plugin-visualizer';
 import { getBabelInputPlugin, getBabelOutputPlugin } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
@@ -201,20 +200,6 @@ export function getRollupConfig(
 	// Polyfill node modules when platform is not node
 	if (!isNode) {
 		config.plugins!.unshift(nodePolyfills());
-	}
-
-	// Analyze the bundle for debugging purposes
-	if (features.analyze) {
-		config.plugins!.push(
-			visualizer((outputOptions) => ({
-				filename: path.join(outputOptions.dir!, artifact.getStatsFileName()),
-				gzipSize: true,
-				open: true,
-				sourcemap: true,
-				template: features.analyze as 'treemap',
-				title: artifact.getStatsTitle(),
-			})),
-		);
 	}
 
 	// Add an output for each format

--- a/packages/packemon/src/schemas.ts
+++ b/packages/packemon/src/schemas.ts
@@ -12,7 +12,6 @@ import {
 	SUPPORTS,
 } from './constants';
 import {
-	AnalyzeType,
 	ApiType,
 	BrowserFormat,
 	BuildOptions,
@@ -73,7 +72,6 @@ export const buildBlueprint: Blueprint<BuildOptions> = {
 	addEngines: bool(),
 	addExports: bool(),
 	addFiles: bool(),
-	analyze: string('none').oneOf<AnalyzeType>(['none', 'sunburst', 'treemap', 'network']),
 	concurrency: number(1).gte(1),
 	declaration: bool(),
 	declarationConfig: string(),

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -52,8 +52,6 @@ export type Format = BrowserFormat | NodeFormat;
 
 export type ApiType = 'private' | 'public';
 
-export type AnalyzeType = 'network' | 'none' | 'sunburst' | 'treemap';
-
 // PACKAGES
 
 export type InputMap = Record<string, string>;
@@ -119,7 +117,6 @@ export interface BuildOptions extends FilterOptions {
 	addEngines?: boolean;
 	addExports?: boolean;
 	addFiles?: boolean;
-	analyze?: AnalyzeType;
 	concurrency?: number;
 	declaration?: boolean;
 	declarationConfig?: string;
@@ -175,7 +172,6 @@ export interface ValidateOptions {
 // CONFIG
 
 export interface FeatureFlags {
-	analyze?: AnalyzeType;
 	decorators?: boolean;
 	flow?: boolean;
 	react?: boolean;

--- a/packages/packemon/tests/CodeArtifact.test.ts
+++ b/packages/packemon/tests/CodeArtifact.test.ts
@@ -85,19 +85,6 @@ describe('CodeArtifact', () => {
 			});
 		});
 
-		it('inherits `analyze` feature flag', async () => {
-			await artifact.build({ analyze: 'network' }, {});
-
-			expect(getRollupConfig).toHaveBeenCalledWith(
-				artifact,
-				{
-					analyze: 'network',
-					typescript: true,
-				},
-				expect.any(Object),
-			);
-		});
-
 		it('sets rollup cache on artifact', async () => {
 			expect(artifact.cache).toBeUndefined();
 

--- a/packages/packemon/tests/CodeArtifact.test.ts
+++ b/packages/packemon/tests/CodeArtifact.test.ts
@@ -1,4 +1,3 @@
-import fs from 'fs-extra';
 import { rollup } from 'rollup';
 import { Path } from '@boost/common';
 import { getFixturePath } from '@boost/test-utils';

--- a/packages/packemon/tests/CodeArtifact.test.ts
+++ b/packages/packemon/tests/CodeArtifact.test.ts
@@ -120,16 +120,6 @@ describe('CodeArtifact', () => {
 		});
 	});
 
-	describe('cleanup()', () => {
-		it('removes visualizer HTML files', async () => {
-			await artifact.cleanup();
-
-			expect(fs.remove).toHaveBeenCalledWith(
-				fixturePath.append('stats-project-node-stable.html').path(),
-			);
-		});
-	});
-
 	describe('getInputPaths()', () => {
 		it('returns an absolute path for every input', () => {
 			expect(artifact.getInputPaths()).toEqual({

--- a/packages/packemon/tests/Packemon.test.ts
+++ b/packages/packemon/tests/Packemon.test.ts
@@ -57,7 +57,6 @@ describe('Packemon', () => {
 				addEngines: true,
 				addExports: false,
 				addFiles: false,
-				analyze: 'none',
 				concurrency: 3,
 				declaration: false,
 				declarationConfig: '',

--- a/packages/packemon/tests/rollup/config.test.ts
+++ b/packages/packemon/tests/rollup/config.test.ts
@@ -23,7 +23,6 @@ jest.mock(
 	() => (options: any) => `externals(${options.packagePath})`,
 );
 jest.mock('rollup-plugin-polyfill-node', () => () => `polyfillNode()`);
-jest.mock('rollup-plugin-visualizer', () => (options: any) => `visualizer(${typeof options})`);
 
 const fixturePath = new Path(getFixturePath('project-rollup'));
 const srcInputFile = fixturePath.append('src/index.ts').path();
@@ -270,14 +269,6 @@ describe('getRollupConfig()', () => {
 		expect(getRollupConfig(artifact, {}).cache).toEqual({
 			modules: [],
 		});
-	});
-
-	it('includes analyzer plugin if `analyze` feature flag is on', () => {
-		artifact.builds.push({ format: 'lib' });
-		expect(getRollupConfig(artifact, { analyze: 'treemap' }).plugins).toEqual([
-			...sharedPlugins,
-			'visualizer(function)',
-		]);
 	});
 
 	it('can mutate config', () => {

--- a/website/docs/build.md
+++ b/website/docs/build.md
@@ -29,11 +29,6 @@ Build supports the following command line options.
   `inputs`. This is an experimental Node.js feature and may not work correctly
   ([more information](https://nodejs.org/api/packages.html#packages_package_entry_points)).
 - `--addFiles` - Add `files` whitelist entries to each `package.json`.
-- `--analyze` - Analyze and visualize all generated builds. Will open a browser visualization for
-  each bundle in one of the following formats.
-  - `sunburst` - Displays an inner circle surrounded by rings of deeper hierarchy levels.
-  - `treemap` - Displays hierarchy levels as top-level and nested rectangles of varying size.
-  - `network` - Displays files as nodes with the relationship between files.
 - `--concurrency` - Number of builds to run in parallel. Defaults to operating system CPU count.
 - `--declaration` - Generate TypeScript declarations for each package.
 - `--declarationConfig` - Path to a custom `tsconfig` for declaration building.

--- a/website/docs/features.md
+++ b/website/docs/features.md
@@ -91,8 +91,6 @@ The following plugins are enabled per package.
   - Includes `dependencies`, `devDependencies`, `peerDependencies`, and `optionalDependencies`.
 - `rollup-plugin-polyfill-node`
   - Polyfills Node.js built-in modules when platform is `browser` or `native`.
-- `rollup-plugin-visualizer`
-  - Analyzes and generates a bundle size visualizer.
 - _Custom_
   - Prepend a Node.js shebang to `bin.*` output files.
 

--- a/website/docs/migrate/2.0.md
+++ b/website/docs/migrate/2.0.md
@@ -20,3 +20,15 @@ Because of this change, the `--declaration` option on the command line is now a 
 # After
 --declaration
 ```
+
+````
+visualizer((outputOptions) => ({
+				filename: path.join(outputOptions.dir!, artifact.getStatsFileName()),
+				gzipSize: true,
+				open: true,
+				sourcemap: true,
+				template: features.analyze as 'treemap',
+				title: artifact.getStatsTitle(),
+			})),
+			```
+````

--- a/website/docs/migrate/2.0.md
+++ b/website/docs/migrate/2.0.md
@@ -21,14 +21,28 @@ Because of this change, the `--declaration` option on the command line is now a 
 --declaration
 ```
 
-````
-visualizer((outputOptions) => ({
-				filename: path.join(outputOptions.dir!, artifact.getStatsFileName()),
+## Removed the `--analyze` option
+
+Since Packemon now supports
+[customizing the Rollup config](../advanced#customizing-babel-and-rollup), the
+[rollup-plugin-visualizer](https://github.com/btd/rollup-plugin-visualizer) plugin can now be
+implemented in user-land, and doesn't need to exist in core.
+
+```js
+const path = require('path');
+const visualizer = require('rollup-plugin-visualizer');
+
+module.exports = {
+	rollupInput(config) {
+		config.plugins.push(
+			visualizer((outputOptions) => ({
+				filename: path.join(outputOptions.dir, 'stats.html'),
 				gzipSize: true,
 				open: true,
 				sourcemap: true,
-				template: features.analyze as 'treemap',
-				title: artifact.getStatsTitle(),
+				template: 'treemap',
 			})),
-			```
-````
+		);
+	},
+};
+```

--- a/yarn.lock
+++ b/yarn.lock
@@ -13206,7 +13206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.32, nanoid@npm:^3.3.1":
+"nanoid@npm:^3.3.1":
   version: 3.3.1
   resolution: "nanoid@npm:3.3.1"
   bin:
@@ -14099,7 +14099,6 @@ __metadata:
     rollup: ^2.70.1
     rollup-plugin-node-externals: ^2.2.0
     rollup-plugin-polyfill-node: ^0.8.0
-    rollup-plugin-visualizer: ^5.6.0
     semver: ^7.3.5
     spdx-license-list: ^6.4.0
   peerDependencies:
@@ -16167,22 +16166,6 @@ resolve@^2.0.0-next.3:
   peerDependencies:
     rollup: ^1.20.0 || ^2.0.0
   checksum: ad6e451b1ae91f7b4370ab7b5dd03f578a67ebd42bcd3eec198ae6d4cd7caa1c454bd020ff8e80f3dcb02cdd9357da2b752c0aac3f84c56a28c23a6c0ffeffd5
-  languageName: node
-  linkType: hard
-
-"rollup-plugin-visualizer@npm:^5.6.0":
-  version: 5.6.0
-  resolution: "rollup-plugin-visualizer@npm:5.6.0"
-  dependencies:
-    nanoid: ^3.1.32
-    open: ^8.4.0
-    source-map: ^0.7.3
-    yargs: ^17.3.1
-  peerDependencies:
-    rollup: ^2.0.0
-  bin:
-    rollup-plugin-visualizer: dist/bin/cli.js
-  checksum: 1036a3873f3b6a0c46d692538aaac5dc9f7a7b2a5aec9e7ab816aaf8a31576ae750f415e1019e401707d18490b634a982fbe8c22d9761cafbd9b12c756e7fd99
   languageName: node
   linkType: hard
 
@@ -19033,21 +19016,6 @@ resolve@^2.0.0-next.3:
     y18n: ^5.0.5
     yargs-parser: ^20.2.2
   checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^17.3.1":
-  version: 17.3.1
-  resolution: "yargs@npm:17.3.1"
-  dependencies:
-    cliui: ^7.0.2
-    escalade: ^3.1.1
-    get-caller-file: ^2.0.5
-    require-directory: ^2.1.1
-    string-width: ^4.2.3
-    y18n: ^5.0.5
-    yargs-parser: ^21.0.0
-  checksum: 64fc2e32c56739f1d14d2d24acd17a6944c3c8e3e3558f09fc1953ac112e868cc16013d282886b9d5be22187f8b9ed4f60741a6b1011f595ce2718805a656852
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This doesn't need to exist in core.