### PR TITLE
new: Ensure package `exports` conditions are sorted correctly.

### DIFF
--- a/packages/babel-plugin-cjs-esm-interop/package.json
+++ b/packages/babel-plugin-cjs-esm-interop/package.json
@@ -46,12 +46,12 @@
   "exports": {
     "./package.json": "./package.json",
     "./*": {
-      "node": "./lib/*.js",
-      "types": "./dts/*.d.ts"
+      "types": "./dts/*.d.ts",
+      "node": "./lib/*.js"
     },
     ".": {
-      "node": "./lib/index.js",
-      "types": "./dts/index.d.ts"
+      "types": "./dts/index.d.ts",
+      "node": "./lib/index.js"
     }
   }
 }

--- a/packages/babel-plugin-conditional-invariant/package.json
+++ b/packages/babel-plugin-conditional-invariant/package.json
@@ -43,12 +43,12 @@
   "exports": {
     "./package.json": "./package.json",
     "./*": {
-      "node": "./lib/*.js",
-      "types": "./dts/*.d.ts"
+      "types": "./dts/*.d.ts",
+      "node": "./lib/*.js"
     },
     ".": {
-      "node": "./lib/index.js",
-      "types": "./dts/index.d.ts"
+      "types": "./dts/index.d.ts",
+      "node": "./lib/index.js"
     }
   }
 }

--- a/packages/babel-plugin-env-constants/package.json
+++ b/packages/babel-plugin-env-constants/package.json
@@ -43,12 +43,12 @@
   "exports": {
     "./package.json": "./package.json",
     "./*": {
-      "node": "./lib/*.js",
-      "types": "./dts/*.d.ts"
+      "types": "./dts/*.d.ts",
+      "node": "./lib/*.js"
     },
     ".": {
-      "node": "./lib/index.js",
-      "types": "./dts/index.d.ts"
+      "types": "./dts/index.d.ts",
+      "node": "./lib/index.js"
     }
   }
 }

--- a/packages/packemon/package.json
+++ b/packages/packemon/package.json
@@ -28,12 +28,12 @@
   "exports": {
     "./package.json": "./package.json",
     "./*": {
-      "node": "./lib/*.js",
-      "types": "./dts/*.d.ts"
+      "types": "./dts/*.d.ts",
+      "node": "./lib/*.js"
     },
     ".": {
-      "node": "./lib/index.js",
-      "types": "./dts/index.d.ts"
+      "types": "./dts/index.d.ts",
+      "node": "./lib/index.js"
     }
   },
   "engines": {

--- a/packages/packemon/src/CodeArtifact.ts
+++ b/packages/packemon/src/CodeArtifact.ts
@@ -199,16 +199,9 @@ export class CodeArtifact extends Artifact<CodeBuild> {
 
 	protected mapPackageExportsFromBuilds(outputName: string, exportMap: PackageExports) {
 		const paths: PackageExportPaths = {};
-		let libPath: PackageExportPaths | string = '';
 
 		this.builds.forEach(({ format }) => {
 			const entry = this.findEntryPoint([format], outputName);
-
-			// Must come after import/require
-			if (paths.default) {
-				libPath = paths.default;
-				delete paths.default;
-			}
 
 			switch (format) {
 				case 'mjs':
@@ -226,7 +219,7 @@ export class CodeArtifact extends Artifact<CodeBuild> {
 					break;
 
 				case 'lib':
-					libPath = entry;
+					paths.default = entry;
 					break;
 
 				default:
@@ -234,15 +227,10 @@ export class CodeArtifact extends Artifact<CodeBuild> {
 			}
 		});
 
-		// Must come after import/require
-		if (libPath) {
-			paths.default = libPath;
-		}
-
 		// eslint-disable-next-line no-param-reassign
 		exportMap[outputName === 'index' ? '.' : `./${outputName}`] = {
 			[this.platform === 'native' ? 'react-native' : this.platform]:
-				Object.keys(paths).length === 1 && libPath ? libPath : paths,
+				Object.keys(paths).length === 1 && paths.default ? paths.default : paths,
 		};
 	}
 }

--- a/packages/packemon/src/Package.ts
+++ b/packages/packemon/src/Package.ts
@@ -19,6 +19,7 @@ import {
 	SUPPORT_PRIORITY,
 } from './constants';
 import { loadModule } from './helpers/loadModule';
+import { sortExportConditions } from './helpers/sortExportConditions';
 import { Project } from './Project';
 import { packemonBlueprint } from './schemas';
 import {
@@ -486,6 +487,12 @@ export class Package {
 
 				Object.assign(exportMap[path], conditions);
 			});
+		});
+
+		// Sort the condition paths
+		Object.entries(exportMap).forEach(([path, conditions]) => {
+			exportMap[path] =
+				typeof conditions === 'string' ? conditions : sortExportConditions(conditions);
 		});
 
 		if (isObject(this.packageJson.exports)) {

--- a/packages/packemon/src/helpers/sortExportConditions.ts
+++ b/packages/packemon/src/helpers/sortExportConditions.ts
@@ -1,11 +1,13 @@
 import { PackageExportPaths } from '../types';
 
 const WEIGHTS = {
-	types: 1, // Types must always be first
-	misc: 2,
-	import: 3,
-	require: 4,
-	default: 10, // Default must be last
+	types: 10, // Types must always be first
+	misc: 20,
+	'node-addons': 30,
+	node: 31,
+	import: 40,
+	require: 50,
+	default: 100, // Default must be last
 };
 
 export function sortExportConditions(paths: PackageExportPaths): PackageExportPaths {
@@ -15,7 +17,7 @@ export function sortExportConditions(paths: PackageExportPaths): PackageExportPa
 		pathsList.push({
 			weight: key in WEIGHTS ? WEIGHTS[key as 'misc'] : WEIGHTS.misc,
 			key,
-			value,
+			value: typeof value === 'string' ? value : sortExportConditions(value),
 		});
 	});
 

--- a/packages/packemon/src/helpers/sortExportConditions.ts
+++ b/packages/packemon/src/helpers/sortExportConditions.ts
@@ -1,5 +1,6 @@
 import { PackageExportPaths } from '../types';
 
+// https://nodejs.org/api/packages.html#conditional-exports
 const WEIGHTS = {
 	types: 10, // Types must always be first
 	misc: 20,
@@ -21,7 +22,11 @@ export function sortExportConditions(paths: PackageExportPaths): PackageExportPa
 		});
 	});
 
-	pathsList.sort((a, d) => a.weight - d.weight);
+	pathsList.sort((a, d) => {
+		const diff = a.weight - d.weight;
+
+		return diff === 0 ? a.key.localeCompare(d.key) : diff;
+	});
 
 	return Object.fromEntries(pathsList.map((path) => [path.key, path.value]));
 }

--- a/packages/packemon/src/helpers/sortExportConditions.ts
+++ b/packages/packemon/src/helpers/sortExportConditions.ts
@@ -1,0 +1,25 @@
+import { PackageExportPaths } from '../types';
+
+const WEIGHTS = {
+	types: 1, // Types must always be first
+	misc: 2,
+	import: 3,
+	require: 4,
+	default: 10, // Default must be last
+};
+
+export function sortExportConditions(paths: PackageExportPaths): PackageExportPaths {
+	const pathsList: { weight: number; key: string; value: PackageExportPaths | string }[] = [];
+
+	Object.entries(paths).forEach(([key, value]) => {
+		pathsList.push({
+			weight: key in WEIGHTS ? WEIGHTS[key as 'misc'] : WEIGHTS.misc,
+			key,
+			value,
+		});
+	});
+
+	pathsList.sort((a, d) => a.weight - d.weight);
+
+	return Object.fromEntries(pathsList.map((path) => [path.key, path.value]));
+}

--- a/packages/packemon/src/swc/config.ts
+++ b/packages/packemon/src/swc/config.ts
@@ -95,7 +95,7 @@ export function getSwcInputConfig(
 		jsc: {
 			parser: {
 				syntax: 'ecmascript',
-				jsx: features.react,
+				jsx: !!features.react,
 				dynamicImport: true,
 			},
 			transform,
@@ -109,7 +109,7 @@ export function getSwcInputConfig(
 	if (features.typescript) {
 		const parser: TsParserConfig = {
 			syntax: 'typescript',
-			tsx: features.react,
+			tsx: !!features.react,
 			dynamicImport: true,
 		};
 
@@ -124,7 +124,7 @@ export function getSwcInputConfig(
 	if (features.react) {
 		transform.react = {
 			development: __DEV__,
-			runtime: 'classic',
+			runtime: features.react,
 			throwIfNamespace: true,
 		};
 	}

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -88,10 +88,12 @@ export interface PackageConfig {
 // https://webpack.js.org/guides/package-exports
 
 export type PackageExportConditions =
+	| 'asset'
 	| 'browser'
 	| 'default'
 	| 'deno'
 	| 'development'
+	| 'electron'
 	| 'import'
 	| 'module'
 	| 'node-addons'
@@ -99,6 +101,8 @@ export type PackageExportConditions =
 	| 'production'
 	| 'react-native'
 	| 'require'
+	| 'script'
+	| 'style'
 	| 'types';
 
 export type PackageExportPaths = {

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -90,9 +90,13 @@ export interface PackageConfig {
 export type PackageExportConditions =
 	| 'browser'
 	| 'default'
+	| 'deno'
+	| 'development'
 	| 'import'
 	| 'module'
+	| 'node-addons'
 	| 'node'
+	| 'production'
 	| 'react-native'
 	| 'require'
 	| 'types';

--- a/packages/packemon/tests/examples/react.test.ts
+++ b/packages/packemon/tests/examples/react.test.ts
@@ -16,5 +16,5 @@ describe.skip('React/JSX', () => {
 	});
 
 	// Automatic only
-	testExampleOutput('react.tsx');
+	testExampleOutput('react.tsx', 'babel');
 });

--- a/packages/packemon/tests/helpers/sortExportConditions.test.ts
+++ b/packages/packemon/tests/helpers/sortExportConditions.test.ts
@@ -1,0 +1,25 @@
+import { sortExportConditions } from '../../src/helpers/sortExportConditions';
+
+describe('sortExportConditions()', () => {
+	it('sorts in the correct order', () => {
+		const map = sortExportConditions({
+			default: '',
+			script: '',
+			import: '',
+			node: '',
+			require: '',
+			types: '',
+			browser: '',
+		});
+
+		expect(Object.keys(map)).toStrictEqual([
+			'types',
+			'browser',
+			'script',
+			'node',
+			'import',
+			'require',
+			'default',
+		]);
+	});
+});

--- a/packages/packemon/tests/swc/__snapshots__/config.test.ts.snap
+++ b/packages/packemon/tests/swc/__snapshots__/config.test.ts.snap
@@ -13,7 +13,7 @@ Object {
     "loose": false,
     "parser": Object {
       "dynamicImport": true,
-      "jsx": undefined,
+      "jsx": false,
       "syntax": "ecmascript",
     },
     "preserveAllComments": true,
@@ -39,7 +39,7 @@ Object {
     "loose": false,
     "parser": Object {
       "dynamicImport": true,
-      "jsx": undefined,
+      "jsx": false,
       "syntax": "ecmascript",
     },
     "preserveAllComments": true,
@@ -64,7 +64,7 @@ Object {
     "loose": false,
     "parser": Object {
       "dynamicImport": true,
-      "jsx": undefined,
+      "jsx": false,
       "syntax": "ecmascript",
     },
     "preserveAllComments": true,
@@ -82,7 +82,7 @@ Object {
   "optimizer": undefined,
   "react": Object {
     "development": true,
-    "runtime": "classic",
+    "runtime": "automatic",
     "throwIfNamespace": true,
   },
 }
@@ -102,7 +102,7 @@ Object {
       "decorators": true,
       "dynamicImport": true,
       "syntax": "typescript",
-      "tsx": undefined,
+      "tsx": false,
     },
     "preserveAllComments": true,
     "target": "es2022",
@@ -119,7 +119,7 @@ exports[`getSwcInputConfig() includes typescript parser if \`typescript\` featur
 Object {
   "dynamicImport": true,
   "syntax": "typescript",
-  "tsx": undefined,
+  "tsx": false,
 }
 `;
 
@@ -137,7 +137,7 @@ Object {
       "decorators": true,
       "dynamicImport": true,
       "syntax": "typescript",
-      "tsx": undefined,
+      "tsx": false,
     },
     "preserveAllComments": true,
     "target": "es2022",

--- a/packages/packemon/tests/swc/config.test.ts
+++ b/packages/packemon/tests/swc/config.test.ts
@@ -15,7 +15,9 @@ describe('getSwcInputConfig()', () => {
 	});
 
 	it('includes react transformer if `react` feature flag is true', () => {
-		expect(getSwcInputConfig(bundleArtifact, { react: true }).jsc?.transform).toMatchSnapshot();
+		expect(
+			getSwcInputConfig(bundleArtifact, { react: 'automatic' }).jsc?.transform,
+		).toMatchSnapshot();
 	});
 
 	it('includes typescript parser if `typescript` feature flag is true', () => {


### PR DESCRIPTION
With TS 4.7 support `exports` (and `types` condition), we must ensure a correct order since `types` must be first.