### PR TITLE
fix: Improve handling of `default` for package exports.

### DIFF
--- a/packages/babel-plugin-cjs-esm-interop/package.json
+++ b/packages/babel-plugin-cjs-esm-interop/package.json
@@ -47,11 +47,13 @@
     "./package.json": "./package.json",
     "./*": {
       "types": "./dts/*.d.ts",
-      "node": "./lib/*.js"
+      "node": "./lib/*.js",
+      "default": "./lib/*.js"
     },
     ".": {
       "types": "./dts/index.d.ts",
-      "node": "./lib/index.js"
+      "node": "./lib/index.js",
+      "default": "./lib/index.js"
     }
   }
 }

--- a/packages/babel-plugin-conditional-invariant/package.json
+++ b/packages/babel-plugin-conditional-invariant/package.json
@@ -44,11 +44,13 @@
     "./package.json": "./package.json",
     "./*": {
       "types": "./dts/*.d.ts",
-      "node": "./lib/*.js"
+      "node": "./lib/*.js",
+      "default": "./lib/*.js"
     },
     ".": {
       "types": "./dts/index.d.ts",
-      "node": "./lib/index.js"
+      "node": "./lib/index.js",
+      "default": "./lib/index.js"
     }
   }
 }

--- a/packages/babel-plugin-env-constants/package.json
+++ b/packages/babel-plugin-env-constants/package.json
@@ -44,11 +44,13 @@
     "./package.json": "./package.json",
     "./*": {
       "types": "./dts/*.d.ts",
-      "node": "./lib/*.js"
+      "node": "./lib/*.js",
+      "default": "./lib/*.js"
     },
     ".": {
       "types": "./dts/index.d.ts",
-      "node": "./lib/index.js"
+      "node": "./lib/index.js",
+      "default": "./lib/index.js"
     }
   }
 }

--- a/packages/packemon/src/CodeArtifact.ts
+++ b/packages/packemon/src/CodeArtifact.ts
@@ -234,11 +234,17 @@ export class CodeArtifact extends Artifact<CodeBuild> {
 			}
 		});
 
-		// eslint-disable-next-line no-param-reassign
-		exportMap[outputName === 'index' ? '.' : `./${outputName}`] = {
-			[this.platform === 'native' ? 'react-native' : this.platform]: paths,
-			// Provide fallbacks if condition above is not met
-			default: paths.default,
+		const pathsMap = {
+			[this.platform === 'native' ? 'react-native' : this.platform]:
+				Object.keys(paths).length === 1 && paths.default ? paths.default : paths,
 		};
+
+		// Provide fallbacks if condition above is not
+		if (paths.default) {
+			pathsMap.default = paths.default;
+		}
+
+		// eslint-disable-next-line no-param-reassign
+		exportMap[outputName === 'index' ? '.' : `./${outputName}`] = pathsMap;
 	}
 }

--- a/packages/packemon/src/CodeArtifact.ts
+++ b/packages/packemon/src/CodeArtifact.ts
@@ -236,8 +236,9 @@ export class CodeArtifact extends Artifact<CodeBuild> {
 
 		// eslint-disable-next-line no-param-reassign
 		exportMap[outputName === 'index' ? '.' : `./${outputName}`] = {
-			[this.platform === 'native' ? 'react-native' : this.platform]:
-				Object.keys(paths).length === 1 && paths.default ? paths.default : paths,
+			[this.platform === 'native' ? 'react-native' : this.platform]: paths,
+			// Provide fallbacks if condition above is not met
+			default: paths.default,
 		};
 	}
 }

--- a/packages/packemon/src/CodeArtifact.ts
+++ b/packages/packemon/src/CodeArtifact.ts
@@ -201,6 +201,7 @@ export class CodeArtifact extends Artifact<CodeBuild> {
 
 	protected mapPackageExportsFromBuilds(outputName: string, exportMap: PackageExports) {
 		const paths: PackageExportPaths = {};
+		let defaultEntry = '';
 
 		this.builds.forEach(({ format }) => {
 			const entry = this.findEntryPoint([format], outputName);
@@ -226,7 +227,7 @@ export class CodeArtifact extends Artifact<CodeBuild> {
 					break;
 
 				case 'lib':
-					paths.default = entry;
+					defaultEntry = entry;
 					break;
 
 				default:
@@ -236,12 +237,12 @@ export class CodeArtifact extends Artifact<CodeBuild> {
 
 		const pathsMap = {
 			[this.platform === 'native' ? 'react-native' : this.platform]:
-				Object.keys(paths).length === 1 && paths.default ? paths.default : paths,
+				Object.keys(paths).length === 0 && defaultEntry ? defaultEntry : paths,
 		};
 
 		// Provide fallbacks if condition above is not
-		if (paths.default) {
-			pathsMap.default = paths.default;
+		if (defaultEntry) {
+			pathsMap.default = defaultEntry;
 		}
 
 		// eslint-disable-next-line no-param-reassign

--- a/packages/packemon/src/Package.ts
+++ b/packages/packemon/src/Package.ts
@@ -489,13 +489,17 @@ export class Package {
 
 		this.artifacts.forEach((artifact) => {
 			Object.entries(artifact.getPackageExports()).forEach(([path, conditions]) => {
+				if (!conditions) {
+					return;
+				}
+
 				if (!exportMap[path]) {
 					exportMap[path] = {};
 				} else if (typeof exportMap[path] === 'string') {
 					exportMap[path] = { default: exportMap[path] };
 				}
 
-				Object.assign(exportMap[path], conditions);
+				Object.assign(exportMap[path]!, conditions);
 			});
 		});
 

--- a/packages/packemon/src/helpers/sortExportConditions.ts
+++ b/packages/packemon/src/helpers/sortExportConditions.ts
@@ -11,8 +11,10 @@ const WEIGHTS = {
 	default: 100, // Default must be last
 };
 
-export function sortExportConditions<T extends PackageExportPaths | string>(paths: T): T {
-	if (typeof paths === 'string') {
+export function sortExportConditions<T extends PackageExportPaths | string | undefined>(
+	paths: T,
+): T {
+	if (!paths || typeof paths === 'string') {
 		return paths;
 	}
 

--- a/packages/packemon/src/helpers/sortExports.ts
+++ b/packages/packemon/src/helpers/sortExports.ts
@@ -15,5 +15,10 @@ export function sortExports(exportMap: PackageExports): PackageExports {
 		return diff === 0 ? d.length - a.length : diff;
 	});
 
-	return Object.fromEntries(paths.map((path) => [path, sortExportConditions(exportMap[path])]));
+	return Object.fromEntries(
+		paths.map((path) => [
+			path,
+			exportMap[path] === undefined ? undefined : sortExportConditions(exportMap[path]),
+		]),
+	);
 }

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -109,7 +109,7 @@ export type PackageExportPaths = {
 	[K in PackageExportConditions]?: PackageExportPaths | string;
 };
 
-export type PackageExports = Record<string, PackageExportPaths | string>;
+export type PackageExports = Record<string, PackageExportPaths | string | undefined>;
 
 // BUILD
 

--- a/packages/packemon/tests/CodeArtifact.test.ts
+++ b/packages/packemon/tests/CodeArtifact.test.ts
@@ -253,7 +253,6 @@ describe('CodeArtifact', () => {
 					node: {
 						import: './mjs/index.mjs',
 						require: './cjs/index.cjs',
-						default: './lib/index.js',
 					},
 					default: './lib/index.js',
 				},

--- a/packages/packemon/tests/CodeArtifact.test.ts
+++ b/packages/packemon/tests/CodeArtifact.test.ts
@@ -216,6 +216,7 @@ describe('CodeArtifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'.': {
 					node: './lib/index.js',
+					default: './lib/index.js',
 				},
 			});
 		});
@@ -227,6 +228,7 @@ describe('CodeArtifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'.': {
 					node: './lib/node/index.js',
+					default: './lib/node/index.js',
 				},
 			});
 		});
@@ -238,6 +240,7 @@ describe('CodeArtifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'./sub': {
 					node: './lib/sub.js',
+					default: './lib/sub.js',
 				},
 			});
 		});
@@ -252,6 +255,7 @@ describe('CodeArtifact', () => {
 						require: './cjs/index.cjs',
 						default: './lib/index.js',
 					},
+					default: './lib/index.js',
 				},
 			});
 		});
@@ -277,6 +281,7 @@ describe('CodeArtifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'.': {
 					browser: './lib/index.js',
+					default: './lib/index.js',
 				},
 			});
 		});
@@ -288,6 +293,7 @@ describe('CodeArtifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'.': {
 					'react-native': './lib/index.js',
+					default: './lib/index.js',
 				},
 			});
 		});

--- a/packages/packemon/tests/Package.test.ts
+++ b/packages/packemon/tests/Package.test.ts
@@ -530,7 +530,7 @@ describe('Package', () => {
 				await pkg.build({ addExports: true }, config);
 
 				expect(pkg.packageJson.exports).toEqual({
-					'.': { node: './lib/index.js' },
+					'.': { node: './lib/index.js', default: './lib/index.js' },
 					'./package.json': './package.json',
 				});
 			});
@@ -549,6 +549,7 @@ describe('Package', () => {
 							require: './cjs/index.cjs',
 							default: './lib/index.js',
 						},
+						default: './lib/index.js',
 					},
 					'./package.json': './package.json',
 				});
@@ -574,6 +575,7 @@ describe('Package', () => {
 						node: './lib/node/index.js',
 						browser: './lib/browser/index.js',
 						'react-native': './lib/native/index.js',
+						default: './lib/native/index.js',
 					},
 					'./package.json': './package.json',
 				});
@@ -603,6 +605,7 @@ describe('Package', () => {
 							module: './esm/index.js',
 							default: './lib/index.js',
 						},
+						default: './lib/index.js',
 					},
 					'./package.json': './package.json',
 				});
@@ -619,8 +622,8 @@ describe('Package', () => {
 				await pkg.build({ addExports: true }, config);
 
 				expect(pkg.packageJson.exports).toEqual({
-					'.': { node: './lib/index.js' },
-					'./client': { browser: './lib/client.js' },
+					'.': { node: './lib/index.js', default: './lib/index.js' },
+					'./client': { browser: './lib/client.js', default: './lib/client.js' },
 					'./package.json': './package.json',
 				});
 			});
@@ -645,6 +648,7 @@ describe('Package', () => {
 							require: './cjs/index.cjs',
 							default: './lib/index.js',
 						},
+						default: './lib/index.js',
 					},
 					'./client': {
 						browser: {
@@ -652,6 +656,7 @@ describe('Package', () => {
 							module: './esm/client.js',
 							default: './lib/client.js',
 						},
+						default: './lib/client.js',
 					},
 					'./package.json': './package.json',
 				});
@@ -664,7 +669,7 @@ describe('Package', () => {
 				await pkg.build({ addExports: true }, config);
 
 				expect(pkg.packageJson.exports).toEqual({
-					'.': { node: './lib/index.js', types: './dts/index.d.ts' },
+					'.': { node: './lib/index.js', types: './dts/index.d.ts', default: './lib/index.js' },
 					'./package.json': './package.json',
 				});
 			});
@@ -679,7 +684,7 @@ describe('Package', () => {
 				await pkg.build({ addExports: true }, config);
 
 				expect(pkg.packageJson.exports).toEqual({
-					'.': { node: './lib/index.js' },
+					'.': { node: './lib/index.js', default: './lib/index.js' },
 					'./foo': './lib/foo.js',
 					'./package.json': './package.json',
 				});
@@ -868,13 +873,14 @@ describe('Package', () => {
 					exports: {
 						'./package.json': './package.json',
 						'.': { node: { import: './cjs/index-wrapper.mjs', require: './cjs/index.cjs' } },
-						'./bin': { node: './lib/bin.js' },
+						'./bin': { node: './lib/bin.js', default: './lib/bin.js' },
 						'./web': {
 							browser: {
 								import: './esm/web.js',
 								module: './esm/web.js',
 								default: './lib/web.js',
 							},
+							default: './lib/web.js',
 						},
 						'./import': { node: { import: './mjs/import.mjs' } },
 					},
@@ -917,10 +923,11 @@ describe('Package', () => {
 					bin: './lib/cli.js',
 					exports: {
 						'./package.json': './package.json',
-						'./bin': { node: './lib/cli.js' },
+						'./bin': { node: './lib/cli.js', default: './lib/cli.js' },
 						'./import': { node: { import: './mjs/web.mjs' } },
 						'./web': {
 							browser: { default: './lib/web.js', import: './esm/web.js', module: './esm/web.js' },
+							default: './lib/web.js',
 						},
 						'.': { node: { import: './cjs/node-wrapper.mjs', require: './cjs/node.cjs' } },
 					},
@@ -966,6 +973,7 @@ describe('Package', () => {
 						'./*': {
 							browser: { import: './esm/*.js', module: './esm/*.js', default: './lib/*.js' },
 							node: { import: './mjs/*.mjs' },
+							default: './lib/*.js',
 						},
 						'.': {
 							browser: {
@@ -974,6 +982,7 @@ describe('Package', () => {
 								default: './lib/index.js',
 							},
 							node: { import: './mjs/index.mjs' },
+							default: './lib/index.js',
 						},
 					},
 				}),

--- a/packages/packemon/tests/Package.test.ts
+++ b/packages/packemon/tests/Package.test.ts
@@ -547,7 +547,6 @@ describe('Package', () => {
 						node: {
 							import: './mjs/index.mjs',
 							require: './cjs/index.cjs',
-							default: './lib/index.js',
 						},
 						default: './lib/index.js',
 					},
@@ -598,12 +597,10 @@ describe('Package', () => {
 						node: {
 							import: './mjs/index.mjs',
 							require: './cjs/index.cjs',
-							default: './lib/index.js',
 						},
 						browser: {
 							import: './esm/index.js',
 							module: './esm/index.js',
-							default: './lib/index.js',
 						},
 						default: './lib/index.js',
 					},
@@ -646,7 +643,6 @@ describe('Package', () => {
 						node: {
 							import: './mjs/index.mjs',
 							require: './cjs/index.cjs',
-							default: './lib/index.js',
 						},
 						default: './lib/index.js',
 					},
@@ -654,7 +650,6 @@ describe('Package', () => {
 						browser: {
 							import: './esm/client.js',
 							module: './esm/client.js',
-							default: './lib/client.js',
 						},
 						default: './lib/client.js',
 					},
@@ -878,7 +873,6 @@ describe('Package', () => {
 							browser: {
 								import: './esm/web.js',
 								module: './esm/web.js',
-								default: './lib/web.js',
 							},
 							default: './lib/web.js',
 						},
@@ -926,7 +920,7 @@ describe('Package', () => {
 						'./bin': { node: './lib/cli.js', default: './lib/cli.js' },
 						'./import': { node: { import: './mjs/web.mjs' } },
 						'./web': {
-							browser: { default: './lib/web.js', import: './esm/web.js', module: './esm/web.js' },
+							browser: { import: './esm/web.js', module: './esm/web.js' },
 							default: './lib/web.js',
 						},
 						'.': { node: { import: './cjs/node-wrapper.mjs', require: './cjs/node.cjs' } },
@@ -971,7 +965,7 @@ describe('Package', () => {
 					exports: {
 						'./package.json': './package.json',
 						'./*': {
-							browser: { import: './esm/*.js', module: './esm/*.js', default: './lib/*.js' },
+							browser: { import: './esm/*.js', module: './esm/*.js' },
 							node: { import: './mjs/*.mjs' },
 							default: './lib/*.js',
 						},
@@ -979,7 +973,6 @@ describe('Package', () => {
 							browser: {
 								import: './esm/index.js',
 								module: './esm/index.js',
-								default: './lib/index.js',
 							},
 							node: { import: './mjs/index.mjs' },
 							default: './lib/index.js',


### PR DESCRIPTION
We've noticed that browser only builds were failing to find imports in tools like webpack and jest.

I'm assuming it's because the `browser` condition isn't being hit, which in turn doesn't hit `default`. This change bubbles up `default` one level for this to be hit.