### PR TITLE
fix: Properly handle package exports for dual formats.

### DIFF
--- a/packages/packemon/src/Package.ts
+++ b/packages/packemon/src/Package.ts
@@ -3,7 +3,7 @@
 import glob from 'fast-glob';
 import fs from 'fs-extra';
 import semver from 'semver';
-import { isObject, Memoize, PackageStructure, Path, toArray } from '@boost/common';
+import { deepMerge, isObject, Memoize, PackageStructure, Path, toArray } from '@boost/common';
 import { optimal } from '@boost/common/optimal';
 import { createDebugger, Debugger } from '@boost/debug';
 import { Artifact } from './Artifact';
@@ -29,6 +29,7 @@ import {
 	FeatureFlags,
 	InputMap,
 	PackageConfig,
+	PackageExportPaths,
 	PackageExports,
 	PackemonPackage,
 	PackemonPackageConfig,
@@ -503,12 +504,18 @@ export class Package {
 				}
 
 				if (!exportMap[path]) {
-					exportMap[path] = {};
-				} else if (typeof exportMap[path] === 'string') {
+					exportMap[path] = conditions;
+					return;
+				}
+
+				if (typeof exportMap[path] === 'string') {
 					exportMap[path] = { default: exportMap[path] };
 				}
 
-				Object.assign(exportMap[path]!, conditions);
+				exportMap[path] = deepMerge<PackageExportPaths, PackageExportPaths>(
+					exportMap[path] as PackageExportPaths,
+					typeof conditions === 'string' ? { default: conditions } : conditions,
+				);
 			});
 		});
 

--- a/packages/packemon/tests/Package.test.ts
+++ b/packages/packemon/tests/Package.test.ts
@@ -700,6 +700,23 @@ describe('Package', () => {
 					'./package.json': './package.json',
 				});
 			});
+
+			it('supports dual cjs/mjs exports', async () => {
+				pkg.addArtifact(createCodeArtifact([{ format: 'cjs' }]));
+				pkg.addArtifact(createCodeArtifact([{ format: 'mjs' }], 'node', 'experimental'));
+
+				await pkg.build({ addExports: true }, config);
+
+				expect(pkg.packageJson.exports).toEqual({
+					'.': {
+						node: {
+							import: './mjs/index.mjs',
+							require: './cjs/index.cjs',
+						},
+					},
+					'./package.json': './package.json',
+				});
+			});
 		});
 
 		describe('files', () => {


### PR DESCRIPTION
Instead of overwriting with `Object.assign()`, use a deep merge approach.