### PR TITLE
fix: Update `tsc` to build project references based on the state of the local config.

### DIFF
--- a/packages/packemon/src/Package.ts
+++ b/packages/packemon/src/Package.ts
@@ -198,7 +198,7 @@ export class Package {
 		}
 
 		// TypeScript
-		const tsConfig = this.tsconfigJson ?? this.project.rootPackage.tsconfigJson;
+		const tsConfig = this.loadTsconfigJson() ?? this.project.rootPackage.loadTsconfigJson();
 
 		if (
 			this.project.rootPackage.hasDependency('typescript') ||
@@ -343,8 +343,8 @@ export class Package {
 	}
 
 	@Memoize()
-	get tsconfigJson(): TSConfigStructure | undefined {
-		const tsconfigJsonPath = this.path.append('tsconfig.json');
+	loadTsconfigJson(configName: string = 'tsconfig.json'): TSConfigStructure | undefined {
+		const tsconfigJsonPath = this.path.append(configName);
 
 		if (!tsconfigJsonPath.exists()) {
 			return undefined;

--- a/packages/packemon/src/TypesArtifact.ts
+++ b/packages/packemon/src/TypesArtifact.ts
@@ -19,7 +19,7 @@ export class TypesArtifact extends Artifact<TypesBuild> {
 		const { declarationConfig } = options;
 
 		// If the local project is using project references, we must build it individually
-		const tsConfig = this.package.loadTsconfigJson(declarationConfig ?? 'tsconfig.json');
+		const tsConfig = this.loadTsconfigJson(declarationConfig ?? 'tsconfig.json');
 
 		if (tsConfig?.projectReferences && tsConfig?.projectReferences.length > 0) {
 			await this.generateDeclarations();
@@ -115,7 +115,7 @@ export class TypesArtifact extends Artifact<TypesBuild> {
 
 	// This method only exists so that we can mock in tests.
 	// istanbul ignore next
-	protected loadTsconfigJson(): TSConfigStructure | undefined {
-		return this.package.loadTsconfigJson();
+	loadTsconfigJson(configName?: string): TSConfigStructure | undefined {
+		return this.package.loadTsconfigJson(configName);
 	}
 }

--- a/packages/packemon/src/TypesArtifact.ts
+++ b/packages/packemon/src/TypesArtifact.ts
@@ -21,7 +21,10 @@ export class TypesArtifact extends Artifact<TypesBuild> {
 		// If the local project is using project references, we must build it individually
 		const tsConfig = this.loadTsconfigJson(declarationConfig ?? 'tsconfig.json');
 
-		if (tsConfig?.projectReferences && tsConfig?.projectReferences.length > 0) {
+		if (
+			tsConfig?.options?.composite ||
+			(tsConfig?.projectReferences && tsConfig?.projectReferences.length > 0)
+		) {
 			await this.generateDeclarations();
 
 			return;

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -238,4 +238,5 @@ export interface TSConfigStructure {
 		outDir?: string;
 		strict?: boolean;
 	};
+	projectReferences?: readonly unknown[];
 }

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -234,6 +234,7 @@ export type Awaitable = Promise<void> | void;
 export interface TSConfigStructure {
 	options: {
 		declarationDir?: string;
+		composite?: boolean;
 		experimentalDecorators?: boolean;
 		outDir?: string;
 		strict?: boolean;

--- a/packages/packemon/tests/Package.test.ts
+++ b/packages/packemon/tests/Package.test.ts
@@ -1517,15 +1517,15 @@ describe('Package', () => {
 		});
 	});
 
-	describe('tsconfigJson()', () => {
+	describe('loadTsconfigJson()', () => {
 		it('returns undefined if no `tsconfig.json` in package', () => {
-			expect(pkg.tsconfigJson).toBeUndefined();
+			expect(pkg.loadTsconfigJson()).toBeUndefined();
 		});
 
 		it('returns options from `tsconfig.json` in package', () => {
 			pkg = loadPackage('ts-config');
 
-			expect(pkg.tsconfigJson).toEqual(
+			expect(pkg.loadTsconfigJson()).toEqual(
 				expect.objectContaining({
 					options: {
 						configFilePath: new VirtualPath(pkg.path.append('tsconfig.json')).path(),

--- a/packages/packemon/tests/Project.test.ts
+++ b/packages/packemon/tests/Project.test.ts
@@ -76,30 +76,6 @@ describe('Project', () => {
 			);
 		});
 
-		// it('generates declarations with `tsc --build` when using workspaces', async () => {
-		// 	const project = new Project(getFixturePath('workspaces'));
-		// 	project.workspaces = ['packages/*'];
-
-		// 	await project.generateDeclarations();
-
-		// 	expect(execa).toHaveBeenCalledWith('tsc', ['--build', '--force'], {
-		// 		cwd: project.root.path(),
-		// 		preferLocal: true,
-		// 	});
-		// });
-
-		// it('generates declarations with `tsc --build` for a specific project', async () => {
-		// 	const project = new Project(getFixturePath('workspaces'));
-		// 	project.workspaces = ['packages/*'];
-
-		// 	await project.generateDeclarations(project.root.append('packages/foo'));
-
-		// 	expect(execa).toHaveBeenCalledWith('tsc', ['--build', '--force', 'packages/foo'], {
-		// 		cwd: project.root.path(),
-		// 		preferLocal: true,
-		// 	});
-		// });
-
 		it('reuses the same promise while building', async () => {
 			mockSpy(execa)
 				.mockReset()
@@ -138,37 +114,6 @@ describe('Project', () => {
 				},
 			);
 		});
-
-		// it('can pass a custom tsconfig when using workspaces', async () => {
-		// 	const project = new Project(getFixturePath('workspaces'));
-		// 	project.workspaces = ['packages/*'];
-
-		// 	await project.generateDeclarations(
-		// 		project.root.append('packages/foo'),
-		// 		'tsconfig.custom.json',
-		// 	);
-
-		// 	expect(execa).toHaveBeenCalledWith(
-		// 		'tsc',
-		// 		['--build', '--force', 'packages/foo/tsconfig.custom.json'],
-		// 		{
-		// 			cwd: project.root.path(),
-		// 			preferLocal: true,
-		// 		},
-		// 	);
-		// });
-
-		// it('does not pass custom tsconfig when using workspaces and no package', async () => {
-		// 	const project = new Project(getFixturePath('workspaces'));
-		// 	project.workspaces = ['packages/*'];
-
-		// 	await project.generateDeclarations(undefined, 'tsconfig.custom.json');
-
-		// 	expect(execa).toHaveBeenCalledWith('tsc', ['--build', '--force'], {
-		// 		cwd: project.root.path(),
-		// 		preferLocal: true,
-		// 	});
-		// });
 	});
 
 	describe('getWorkspacePackageNames()', () => {

--- a/packages/packemon/tests/Project.test.ts
+++ b/packages/packemon/tests/Project.test.ts
@@ -88,17 +88,17 @@ describe('Project', () => {
 			});
 		});
 
-		it('generates declarations with `tsc --build` for a specific project', async () => {
-			const project = new Project(getFixturePath('workspaces'));
-			project.workspaces = ['packages/*'];
+		// it('generates declarations with `tsc --build` for a specific project', async () => {
+		// 	const project = new Project(getFixturePath('workspaces'));
+		// 	project.workspaces = ['packages/*'];
 
-			await project.generateDeclarations(project.root.append('packages/foo'));
+		// 	await project.generateDeclarations(project.root.append('packages/foo'));
 
-			expect(execa).toHaveBeenCalledWith('tsc', ['--build', '--force', 'packages/foo'], {
-				cwd: project.root.path(),
-				preferLocal: true,
-			});
-		});
+		// 	expect(execa).toHaveBeenCalledWith('tsc', ['--build', '--force', 'packages/foo'], {
+		// 		cwd: project.root.path(),
+		// 		preferLocal: true,
+		// 	});
+		// });
 
 		it('reuses the same promise while building', async () => {
 			mockSpy(execa)
@@ -119,7 +119,7 @@ describe('Project', () => {
 		it('can pass a custom tsconfig', async () => {
 			const project = new Project(getFixturePath('workspace-private'));
 
-			await project.generateDeclarations(undefined, 'tsconfig.custom.json');
+			await project.generateDeclarations('tsconfig.custom.json');
 
 			expect(execa).toHaveBeenCalledWith(
 				'tsc',
@@ -139,36 +139,36 @@ describe('Project', () => {
 			);
 		});
 
-		it('can pass a custom tsconfig when using workspaces', async () => {
-			const project = new Project(getFixturePath('workspaces'));
-			project.workspaces = ['packages/*'];
+		// it('can pass a custom tsconfig when using workspaces', async () => {
+		// 	const project = new Project(getFixturePath('workspaces'));
+		// 	project.workspaces = ['packages/*'];
 
-			await project.generateDeclarations(
-				project.root.append('packages/foo'),
-				'tsconfig.custom.json',
-			);
+		// 	await project.generateDeclarations(
+		// 		project.root.append('packages/foo'),
+		// 		'tsconfig.custom.json',
+		// 	);
 
-			expect(execa).toHaveBeenCalledWith(
-				'tsc',
-				['--build', '--force', 'packages/foo/tsconfig.custom.json'],
-				{
-					cwd: project.root.path(),
-					preferLocal: true,
-				},
-			);
-		});
+		// 	expect(execa).toHaveBeenCalledWith(
+		// 		'tsc',
+		// 		['--build', '--force', 'packages/foo/tsconfig.custom.json'],
+		// 		{
+		// 			cwd: project.root.path(),
+		// 			preferLocal: true,
+		// 		},
+		// 	);
+		// });
 
-		it('does not pass custom tsconfig when using workspaces and no package', async () => {
-			const project = new Project(getFixturePath('workspaces'));
-			project.workspaces = ['packages/*'];
+		// it('does not pass custom tsconfig when using workspaces and no package', async () => {
+		// 	const project = new Project(getFixturePath('workspaces'));
+		// 	project.workspaces = ['packages/*'];
 
-			await project.generateDeclarations(undefined, 'tsconfig.custom.json');
+		// 	await project.generateDeclarations(undefined, 'tsconfig.custom.json');
 
-			expect(execa).toHaveBeenCalledWith('tsc', ['--build', '--force'], {
-				cwd: project.root.path(),
-				preferLocal: true,
-			});
-		});
+		// 	expect(execa).toHaveBeenCalledWith('tsc', ['--build', '--force'], {
+		// 		cwd: project.root.path(),
+		// 		preferLocal: true,
+		// 	});
+		// });
 	});
 
 	describe('getWorkspacePackageNames()', () => {

--- a/packages/packemon/tests/Project.test.ts
+++ b/packages/packemon/tests/Project.test.ts
@@ -76,17 +76,17 @@ describe('Project', () => {
 			);
 		});
 
-		it('generates declarations with `tsc --build` when using workspaces', async () => {
-			const project = new Project(getFixturePath('workspaces'));
-			project.workspaces = ['packages/*'];
+		// it('generates declarations with `tsc --build` when using workspaces', async () => {
+		// 	const project = new Project(getFixturePath('workspaces'));
+		// 	project.workspaces = ['packages/*'];
 
-			await project.generateDeclarations();
+		// 	await project.generateDeclarations();
 
-			expect(execa).toHaveBeenCalledWith('tsc', ['--build', '--force'], {
-				cwd: project.root.path(),
-				preferLocal: true,
-			});
-		});
+		// 	expect(execa).toHaveBeenCalledWith('tsc', ['--build', '--force'], {
+		// 		cwd: project.root.path(),
+		// 		preferLocal: true,
+		// 	});
+		// });
 
 		// it('generates declarations with `tsc --build` for a specific project', async () => {
 		// 	const project = new Project(getFixturePath('workspaces'));

--- a/packages/packemon/tests/TypesArtifact.test.ts
+++ b/packages/packemon/tests/TypesArtifact.test.ts
@@ -47,24 +47,31 @@ describe('TypesArtifact', () => {
 
 	describe('build()', () => {
 		let declSpy: jest.SpyInstance;
+		let declRootSpy: jest.SpyInstance;
 
 		beforeEach(() => {
 			declSpy = jest
+				.spyOn(artifact, 'generateDeclarations')
+				// eslint-disable-next-line @typescript-eslint/no-misused-promises
+				.mockImplementation(() => Promise.resolve());
+
+			declRootSpy = jest
 				.spyOn(artifact.package.project, 'generateDeclarations')
 				.mockImplementation(() => Promise.resolve());
 		});
 
 		afterEach(() => {
 			declSpy.mockRestore();
+			declRootSpy.mockRestore();
 		});
 
-		it('generates types using `tsc`', async () => {
+		it('no refs, runs project `tsc` without --build', async () => {
 			await artifact.build({});
 
-			expect(declSpy).toHaveBeenCalled();
+			expect(declRootSpy).toHaveBeenCalled();
 		});
 
-		it('runs the same `tsc` when using workspaces', async () => {
+		it('with refs, runs package `tsc` with --build', async () => {
 			artifact.package.project.workspaces = ['packages/*'];
 
 			await artifact.build({});

--- a/packages/packemon/tests/TypesArtifact.test.ts
+++ b/packages/packemon/tests/TypesArtifact.test.ts
@@ -89,6 +89,20 @@ describe('TypesArtifact', () => {
 				preferLocal: true,
 			});
 		});
+
+		it('when composite, runs package `tsc` with --build', async () => {
+			tsconfigSpy.mockImplementation(() => ({ options: { composite: true } } as any));
+
+			await artifact.build({});
+
+			expect(declRootSpy).not.toHaveBeenCalled();
+			expect(declSpy).toHaveBeenCalled();
+
+			expect(execa).toHaveBeenCalledWith('tsc', ['--build', '--force'], {
+				cwd: fixturePath.path(),
+				preferLocal: true,
+			});
+		});
 	});
 
 	describe('findEntryPoint()', () => {


### PR DESCRIPTION
Declarations will now choose the correct args to use for `tsc` based on the existence of project references or composite options, per project, instead of at the root.