### PR TITLE
fix: Improve workspace root detection. Fix config loading and validation.

### DIFF
--- a/packages/packemon/src/Package.ts
+++ b/packages/packemon/src/Package.ts
@@ -157,7 +157,7 @@ export class Package {
 		this.debug('Loading feature flags');
 
 		const flags: FeatureFlags =
-			this.root || !this.project.isWorkspacesEnabled()
+			this.root || !this.project.isRunningInWorkspaceRoot()
 				? {}
 				: this.project.rootPackage.getFeatureFlags();
 

--- a/packages/packemon/src/Package.ts
+++ b/packages/packemon/src/Package.ts
@@ -157,7 +157,7 @@ export class Package {
 		this.debug('Loading feature flags');
 
 		const flags: FeatureFlags =
-			this.root || !this.project.isRunningInWorkspaceRoot()
+			this.root || !this.project.isWorkspacesEnabled()
 				? {}
 				: this.project.rootPackage.getFeatureFlags();
 

--- a/packages/packemon/src/Packemon.ts
+++ b/packages/packemon/src/Packemon.ts
@@ -366,6 +366,12 @@ export class Packemon {
 		}
 
 		const parentDir = dir.parent();
+
+		// This is a special case to handle our fixtures
+		if (__TEST__ && parentDir.name() === '__fixtures__') {
+			return dir;
+		}
+
 		const isRoot = parentDir.path();
 
 		if (isRoot === '' || isRoot === '.' || isRoot === '/') {

--- a/packages/packemon/src/Packemon.ts
+++ b/packages/packemon/src/Packemon.ts
@@ -58,11 +58,7 @@ export class Packemon {
 		this.debug('Initializing packemon in project %s', this.root);
 
 		this.project.checkEngineVersionConstraint();
-
-		// Not sure which approach is better here? Build systems run packemon
-		// from the package folder itself, bypasing the "workspace" logic and the root,
-		// but non-build systems run from the root...
-		this.config.setRootDir(this.workingDir);
+		this.config.setRootDir(this.root);
 	}
 
 	async build(baseOptions: BuildOptions) {

--- a/packages/packemon/src/Packemon.ts
+++ b/packages/packemon/src/Packemon.ts
@@ -347,6 +347,14 @@ export class Packemon {
 	 * This is necessary as it changes functionality.
 	 */
 	protected findWorkspaceRoot(dir: Path): Path | undefined {
+		if (
+			dir.append('yarn.lock').exists() ||
+			dir.append('package-lock.json').exists() ||
+			dir.append('pnpm-lock.yaml').exists()
+		) {
+			return dir;
+		}
+
 		const pkgPath = dir.append('package.json');
 
 		if (pkgPath.exists()) {

--- a/packages/packemon/src/Project.ts
+++ b/packages/packemon/src/Project.ts
@@ -2,14 +2,22 @@
 
 import execa from 'execa';
 import semver from 'semver';
-import { Memoize, Project as BaseProject } from '@boost/common';
+import { Memoize, Path, PortablePath, Project as BaseProject } from '@boost/common';
 import { getVersion } from './helpers/getVersion';
 import { Package } from './Package';
 
 export class Project extends BaseProject {
+	readonly workingDir: Path;
+
 	workspaces: string[] = [];
 
 	private buildPromise?: Promise<unknown>;
+
+	constructor(root: PortablePath, cwd?: Path) {
+		super(root);
+
+		this.workingDir = cwd ?? this.root;
+	}
 
 	checkEngineVersionConstraint() {
 		let version = '';
@@ -36,6 +44,10 @@ export class Project extends BaseProject {
 
 	isWorkspacesEnabled(): boolean {
 		return this.workspaces.length > 0;
+	}
+
+	isRunningInWorkspaceRoot(): boolean {
+		return this.root.equals(this.workingDir);
 	}
 
 	async generateDeclarations(declarationConfig?: string): Promise<unknown> {

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -13,6 +13,8 @@ import { Options as SwcOptions } from '@swc/core';
 declare global {
 	// eslint-disable-next-line no-underscore-dangle
 	const __DEV__: boolean;
+	// eslint-disable-next-line no-underscore-dangle
+	const __TEST__: boolean;
 }
 
 export type Platform = 'browser' | 'native' | 'node'; // electron

--- a/packages/packemon/tests/Packemon.test.ts
+++ b/packages/packemon/tests/Packemon.test.ts
@@ -105,6 +105,37 @@ describe('Packemon', () => {
 		});
 	});
 
+	it('detects project root', () => {
+		const root = Path.create(getFixturePath('project'));
+
+		packemon = new Packemon(root);
+
+		expect(packemon.workingDir.path()).toBe(root.path());
+		expect(packemon.root.path()).toBe(root.path());
+		expect(packemon.project.root.path()).toBe(root.path());
+	});
+
+	it('detects workspace root', () => {
+		const root = Path.create(getFixturePath('workspaces'));
+
+		packemon = new Packemon(root);
+
+		expect(packemon.workingDir.path()).toBe(root.path());
+		expect(packemon.root.path()).toBe(root.path());
+		expect(packemon.project.root.path()).toBe(root.path());
+	});
+
+	it('detects workspace root when running in a sub-folder', () => {
+		const root = Path.create(getFixturePath('workspaces'));
+		const sub = root.append('packages/valid-array');
+
+		packemon = new Packemon(sub);
+
+		expect(packemon.workingDir.path()).toBe(sub.path());
+		expect(packemon.root.path()).toBe(root.path());
+		expect(packemon.project.root.path()).toBe(root.path());
+	});
+
 	describe('clean()', () => {
 		it('handles file system failures', async () => {
 			(rimraf as unknown as jest.Mock).mockImplementation((path, cb) => {


### PR DESCRIPTION
Packemon is run in 4 different contexts:

- Polyrepo root (builds 1 package)
- Monorepo root (builds all packages)
- Monorepo root with filters (builds N packages)
- Monorepo project (builds 1 package)


The first 3 work just fine, as they were the intended developer flow for Packemon. However, the 4th is currently "broken". Packages build just fine, but configuration (`package.config.js`, etc) are resolved incorrectly, and any `package.json` validation (mainly repository) fails incorrectly.

To solve this problem, I must detect the "repo root".