### PR TITLE
breaking: Remove `--files` support from validation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@types/jest": "^29.2.0",
     "@types/micromatch": "^4.0.2",
     "@types/node": "^16.18.2",
-    "@types/npm-packlist": "^3.0.0",
     "@types/react": "^17.0.51",
     "@types/semver": "^7.3.13",
     "babel-preset-moon": "^1.1.1",

--- a/packages/packemon/package.json
+++ b/packages/packemon/package.json
@@ -109,7 +109,6 @@
     "ink-spinner": "^4.0.3",
     "magic-string": "^0.26.7",
     "micromatch": "^4.0.5",
-    "npm-packlist": "^5.1.3",
     "react": "^17.0.2",
     "resolve": "^1.22.1",
     "rollup": "^3.2.3",

--- a/packages/packemon/src/PackageValidator.ts
+++ b/packages/packemon/src/PackageValidator.ts
@@ -1,7 +1,6 @@
 import http from 'node:http';
 import https from 'node:https';
 import execa from 'execa';
-import packList from 'npm-packlist';
 import semver from 'semver';
 import spdxLicenses from 'spdx-license-list';
 import {
@@ -53,10 +52,6 @@ export class PackageValidator {
 
 		if (options.entries) {
 			this.checkEntryPoints();
-		}
-
-		if (options.files) {
-			promises.push(this.checkFiles());
 		}
 
 		if (options.license) {
@@ -228,42 +223,6 @@ export class PackageValidator {
 					this.errors.push(`Manual "${path}" resolves to an invalid or missing file.`);
 				}
 			});
-		}
-	}
-
-	protected async checkFiles() {
-		const packListFiles = await packList({ path: this.package.path.path() });
-		const futureFiles = new Set(packListFiles.map((file) => file.replace(/^\.\//, '')));
-		const presentFiles = new Set(await this.package.findDistributableFiles());
-
-		// First check that our files are in the potential npm list
-		const ignored = new Set<string>();
-
-		presentFiles.forEach((file) => {
-			if (!futureFiles.has(file)) {
-				ignored.add(file);
-			}
-		});
-
-		if (ignored.size > 0) {
-			this.errors.push(
-				`The following files are being ignored from publishing: ${[...ignored].join(', ')}`,
-			);
-		}
-
-		// Then check that npm isnt adding something unwanted
-		const unwanted = new Set<string>();
-
-		futureFiles.forEach((file) => {
-			if (!presentFiles.has(file)) {
-				unwanted.add(file);
-			}
-		});
-
-		if (unwanted.size > 0) {
-			this.warnings.push(
-				`The following files are being inadvertently published: ${[...unwanted].join(', ')}`,
-			);
 		}
 	}
 

--- a/packages/packemon/src/commands/Files.tsx
+++ b/packages/packemon/src/commands/Files.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-param-reassign */
 
-import packList from 'npm-packlist';
 import { Arg, Config } from '@boost/cli';
 import type { FileFormat } from '../components/Files';
 import type { FileTree } from '../components/Files/Tree';
@@ -14,7 +13,7 @@ export class FilesCommand extends BaseCommand {
 	format: FileFormat = 'tree';
 	async run() {
 		const pkg = await this.getPackage();
-		const files = await packList({ path: pkg.path.path() });
+		const files = await pkg.findDistributableFiles();
 		const tree = this.convertFilesToTree(files);
 
 		// eslint-disable-next-line import/no-useless-path-segments

--- a/packages/packemon/src/commands/Validate.ts
+++ b/packages/packemon/src/commands/Validate.ts
@@ -13,9 +13,6 @@ export class ValidateCommand extends BaseCommand<Required<ValidateOptions>> {
 	@Arg.Flag('Check that `main`, `module`, and other entry points are valid paths')
 	entries: boolean = true;
 
-	@Arg.Flag('Check that distributable files are not being accidentally ignored')
-	files: boolean = true;
-
 	@Arg.Flag('Check that a SPDX license is provided')
 	license: boolean = true;
 
@@ -38,7 +35,6 @@ export class ValidateCommand extends BaseCommand<Required<ValidateOptions>> {
 			deps: this.deps,
 			engines: this.engines,
 			entries: this.engines,
-			files: this.files,
 			license: this.license,
 			links: this.links,
 			meta: this.meta,

--- a/packages/packemon/src/schemas.ts
+++ b/packages/packemon/src/schemas.ts
@@ -97,7 +97,6 @@ export const validateBlueprint: Blueprint<ValidateOptions> = {
 	deps: bool(true),
 	engines: bool(true),
 	entries: bool(true),
-	files: bool(true),
 	license: bool(true),
 	links: bool(true),
 	meta: bool(true),

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -171,7 +171,6 @@ export interface ValidateOptions {
 	deps?: boolean;
 	engines?: boolean;
 	entries?: boolean;
-	files?: boolean;
 	license?: boolean;
 	links?: boolean;
 	meta?: boolean;

--- a/packages/packemon/tests/PackageValidator.test.ts
+++ b/packages/packemon/tests/PackageValidator.test.ts
@@ -1,6 +1,5 @@
 import execa from 'execa';
 import fs from 'fs-extra';
-import packList from 'npm-packlist';
 import { Path } from '@boost/common';
 import { getFixturePath } from '@boost/test-utils';
 import { Package } from '../src/Package';
@@ -8,7 +7,6 @@ import { PackageValidator } from '../src/PackageValidator';
 import { mockSpy } from './helpers';
 
 jest.mock('execa');
-jest.mock('npm-packlist');
 
 function createValidator(fixture: string) {
 	const root = new Path(getFixturePath(fixture));
@@ -449,44 +447,6 @@ describe('PackageValidator', () => {
 			expect(validator.errors).toEqual([
 				'Missing primary entry point. Provide a `main` or `exports` field.',
 			]);
-		});
-	});
-
-	describe('checkFiles()', () => {
-		beforeEach(() => {
-			validator = createValidator('validate-files');
-		});
-
-		it('errors when local build files are being ignored', async () => {
-			(packList as unknown as jest.Mock).mockReturnValueOnce([
-				'package.json',
-				'esm/index.js',
-				'lib/index.js',
-			]);
-
-			await validator.validate({ files: true });
-
-			expect(validator.warnings).toEqual([]);
-			expect(validator.errors).toEqual([
-				'The following files are being ignored from publishing: src/index.ts',
-			]);
-		});
-
-		it('warns when npm packed files includes unwanted', async () => {
-			(packList as unknown as jest.Mock).mockReturnValueOnce([
-				'package.json',
-				'esm/index.js',
-				'lib/index.js',
-				'src/index.ts',
-				'umd/index.js',
-			]);
-
-			await validator.validate({ files: true });
-
-			expect(validator.warnings).toEqual([
-				'The following files are being inadvertently published: umd/index.js',
-			]);
-			expect(validator.errors).toEqual([]);
 		});
 	});
 

--- a/packages/packemon/tests/Packemon.test.ts
+++ b/packages/packemon/tests/Packemon.test.ts
@@ -143,7 +143,6 @@ describe('Packemon', () => {
 				deps: false,
 				engines: true,
 				entries: true,
-				files: true,
 				license: true,
 				links: true,
 				meta: true,

--- a/website/docs/migrate/3.0.md
+++ b/website/docs/migrate/3.0.md
@@ -152,3 +152,4 @@ requirement. For example, these are simply now `src/**/*` and `cjs/**/*`.
 - Removed `babelrcRoots` support from our internal Babel configuration.
 - Removed the `engines` version constraint feature.
 - Removed the `npm` engine when adding engines with `--addEngines`.
+- Removed the `--files` option from `packemon validate`.

--- a/website/docs/validate.md
+++ b/website/docs/validate.md
@@ -36,7 +36,6 @@ Validate supports the following command line options.
   points are valid by:
   - Requiring either `main` or `exports` to be configured.
   - Verifying the relative path exists on the file system.
-- `--files` - Check that distributable files are not being accidentally ignored.
 - `--license` - Check that `license` is a valid SPDX license and a `LICENSE` (or `LICENSE.md`) file
   exists.
 - `--links` - Check that `homepage` and `bugs` links are valid URLs.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6200,13 +6200,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/npm-packlist@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@types/npm-packlist@npm:3.0.0"
-  checksum: db73f0590ecd5c5091d0306b52f294a448a3e3972b345901410d4deb8fa3221eeeca2751224840f4f830812505a1f9082da3574c9609064aa70377515a40ab9f
-  languageName: node
-  linkType: hard
-
 "@types/parse-json@npm:^4.0.0":
   version: 4.0.0
   resolution: "@types/parse-json@npm:4.0.0"
@@ -16004,7 +15997,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"npm-packlist@npm:^5.1.0, npm-packlist@npm:^5.1.1, npm-packlist@npm:^5.1.3":
+"npm-packlist@npm:^5.1.0, npm-packlist@npm:^5.1.1":
   version: 5.1.3
   resolution: "npm-packlist@npm:5.1.3"
   dependencies:
@@ -16626,7 +16619,6 @@ __metadata:
     "@types/jest": ^29.2.0
     "@types/micromatch": ^4.0.2
     "@types/node": ^16.18.2
-    "@types/npm-packlist": ^3.0.0
     "@types/react": ^17.0.51
     "@types/semver": ^7.3.13
     babel-preset-moon: ^1.1.1
@@ -16683,7 +16675,6 @@ __metadata:
     ink-spinner: ^4.0.3
     magic-string: ^0.26.7
     micromatch: ^4.0.5
-    npm-packlist: ^5.1.3
     react: ^17.0.2
     resolve: ^1.22.1
     rollup: ^3.2.3


### PR DESCRIPTION
npm has changed the way `packlist` works, and it's no longer viable.