### PR TITLE
new: Support `solid` exports automatically.

### DIFF
--- a/packages/packemon/package.json
+++ b/packages/packemon/package.json
@@ -28,38 +28,23 @@
     "./package.json": "./package.json",
     "./babel": {
       "node": {
-        "import": {
-          "types": "./cjs/babel.d.ts",
-          "default": "./cjs/babel-wrapper.mjs"
-        },
-        "require": {
-          "types": "./cjs/babel.d.ts",
-          "default": "./cjs/babel.cjs"
-        }
+        "types": "./cjs/babel.d.ts",
+        "import": "./cjs/babel-wrapper.mjs",
+        "require": "./cjs/babel.cjs"
       }
     },
     "./bin": {
       "node": {
-        "import": {
-          "types": "./cjs/bin.d.ts",
-          "default": "./cjs/bin-wrapper.mjs"
-        },
-        "require": {
-          "types": "./cjs/bin.d.ts",
-          "default": "./cjs/bin.cjs"
-        }
+        "types": "./cjs/bin.d.ts",
+        "import": "./cjs/bin-wrapper.mjs",
+        "require": "./cjs/bin.cjs"
       }
     },
     ".": {
       "node": {
-        "import": {
-          "types": "./cjs/index.d.ts",
-          "default": "./cjs/index-wrapper.mjs"
-        },
-        "require": {
-          "types": "./cjs/index.d.ts",
-          "default": "./cjs/index.cjs"
-        }
+        "types": "./cjs/index.d.ts",
+        "import": "./cjs/index-wrapper.mjs",
+        "require": "./cjs/index.cjs"
       }
     }
   },

--- a/packages/packemon/src/Artifact.ts
+++ b/packages/packemon/src/Artifact.ts
@@ -385,8 +385,14 @@ export class Artifact {
 		};
 
 		// Point to the source files when using solid
-		if (features.solid && outputName !== '*') {
-			pathsMap.solid = this.inputs[outputName];
+		if (features.solid) {
+			if (outputName === '*') {
+				pathsMap.solid = `./src/*.${features.typescript ? 'tsx' : 'js'}`;
+			} else {
+				const input = this.inputs[outputName];
+
+				pathsMap.solid = input.startsWith('./') ? input : `./${input}`;
+			}
 		}
 
 		// Provide fallbacks if condition above is not

--- a/packages/packemon/src/Artifact.ts
+++ b/packages/packemon/src/Artifact.ts
@@ -327,37 +327,69 @@ export class Artifact {
 				const mjsEntry = this.findEntryPoint(['mjs'], outputName);
 				const cjsEntry = this.findEntryPoint(['cjs'], outputName);
 
-				if (mjsEntry || cjsEntry) {
+				if (mjsEntry && cjsEntry) {
 					paths = {
-						import: mjsEntry
-							? {
-									types: mjsEntry.declPath,
-									default: mjsEntry.entryPath,
-							  }
-							: undefined,
-						require: cjsEntry
-							? {
-									types: cjsEntry.declPath,
-									default: cjsEntry.entryPath,
-							  }
-							: undefined,
+						import: {
+							types: mjsEntry.declPath,
+							default: mjsEntry.entryPath,
+						},
+						require: {
+							types: cjsEntry.declPath,
+							default: cjsEntry.entryPath,
+						},
+					};
+				} else if (mjsEntry) {
+					paths = {
+						types: mjsEntry.declPath,
+						import: mjsEntry.entryPath,
+					};
+				} else if (cjsEntry) {
+					paths = {
+						types: cjsEntry.declPath,
+						require: cjsEntry.entryPath,
 					};
 
 					// Automatically apply the mjs wrapper for cjs
-					if (!paths.import && outputName !== '*' && cjsEntry) {
-						paths.import = {
-							types: cjsEntry.declPath,
-							default: cjsEntry.entryPath.replace('.cjs', '-wrapper.mjs'),
-						};
+					if (!paths.import && outputName !== '*') {
+						paths.import = cjsEntry.entryPath.replace('.cjs', '-wrapper.mjs');
 					}
-
-					if (!paths.require && defaultEntry) {
-						paths.default = defaultEntry.entryPath;
-					}
-				} else {
-					paths.types = defaultEntry?.declPath;
-					paths.default = defaultEntry?.entryPath;
 				}
+
+				if (!paths.require && defaultEntry) {
+					paths.default = defaultEntry.entryPath;
+				}
+
+				// if (mjsEntry || cjsEntry) {
+				// 	paths = {
+				// 		import: mjsEntry
+				// 			? {
+				// 					types: mjsEntry.declPath,
+				// 					default: mjsEntry.entryPath,
+				// 			  }
+				// 			: undefined,
+				// 		require: cjsEntry
+				// 			? {
+				// 					types: cjsEntry.declPath,
+				// 					default: cjsEntry.entryPath,
+				// 			  }
+				// 			: undefined,
+				// 	};
+
+				// 	// Automatically apply the mjs wrapper for cjs
+				// 	if (!paths.import && outputName !== '*' && cjsEntry) {
+				// 		paths.import = {
+				// 			types: cjsEntry.declPath,
+				// 			default: cjsEntry.entryPath.replace('.cjs', '-wrapper.mjs'),
+				// 		};
+				// 	}
+
+				// 	if (!paths.require && defaultEntry) {
+				// 		paths.default = defaultEntry.entryPath;
+				// 	}
+				// } else {
+				// 	paths.types = defaultEntry?.declPath;
+				// 	paths.default = defaultEntry?.entryPath;
+				// }
 
 				break;
 			}

--- a/packages/packemon/src/Artifact.ts
+++ b/packages/packemon/src/Artifact.ts
@@ -73,9 +73,11 @@ export class Artifact {
 	/**
 	 * Build code and types in parallel.
 	 */
-	async build(options: BuildOptions, packemonConfig: ConfigFile): Promise<void> {
-		const features = this.package.getFeatureFlags();
-
+	async build(
+		options: BuildOptions,
+		features: FeatureFlags,
+		packemonConfig: ConfigFile,
+	): Promise<void> {
 		await Promise.all([this.buildCode(features, packemonConfig), this.buildTypes(features)]);
 	}
 

--- a/packages/packemon/src/Artifact.ts
+++ b/packages/packemon/src/Artifact.ts
@@ -2,7 +2,7 @@ import execa from 'execa';
 import fs from 'fs-extra';
 import { rollup } from 'rollup';
 import { applyStyle } from '@boost/cli';
-import { Path, toArray, VirtualPath } from '@boost/common';
+import { isObject, Path, toArray, VirtualPath } from '@boost/common';
 import { createDebugger, Debugger } from '@boost/debug';
 import { removeSourcePath } from './helpers/removeSourcePath';
 import type { Package } from './Package';
@@ -355,8 +355,14 @@ export class Artifact {
 					}
 				}
 
-				if (!paths.require && defaultEntry) {
-					paths.default = defaultEntry.entryPath;
+				if (defaultEntry) {
+					if (!paths.types && !isObject(paths.import) && !isObject(paths.require)) {
+						paths.types = defaultEntry.declPath;
+					}
+
+					if (!paths.require) {
+						paths.default = defaultEntry.entryPath;
+					}
 				}
 
 				// if (mjsEntry || cjsEntry) {
@@ -395,6 +401,7 @@ export class Artifact {
 			}
 
 			case 'native':
+				paths.types = defaultEntry?.declPath;
 				paths.default = defaultEntry?.entryPath;
 				break;
 

--- a/packages/packemon/src/Package.ts
+++ b/packages/packemon/src/Package.ts
@@ -103,7 +103,7 @@ export class Package {
 
 		// Add package `exports` based on artifacts
 		if (options.addExports) {
-			this.addExports();
+			this.addExports(features);
 		}
 
 		// Add package `files` whitelist
@@ -475,7 +475,7 @@ export class Package {
 		}
 	}
 
-	protected addExports() {
+	protected addExports(features: FeatureFlags) {
 		this.debug('Adding `exports` to `package.json`');
 
 		let exportMap: PackageExports = {
@@ -483,7 +483,7 @@ export class Package {
 		};
 
 		this.artifacts.forEach((artifact) => {
-			Object.entries(artifact.getPackageExports()).forEach(([path, conditions]) => {
+			Object.entries(artifact.getPackageExports(features)).forEach(([path, conditions]) => {
 				if (conditions) {
 					exportMap[path] = mergeExports(exportMap[path] ?? {}, conditions);
 				}

--- a/packages/packemon/src/Package.ts
+++ b/packages/packemon/src/Package.ts
@@ -71,6 +71,8 @@ export class Package {
 		this.debug('Building artifacts');
 
 		// Build artifacts in parallel
+		const features = this.getFeatureFlags();
+
 		await Promise.all(
 			this.artifacts.map(async (artifact) => {
 				const start = Date.now();
@@ -78,7 +80,7 @@ export class Package {
 				try {
 					artifact.state = 'building';
 
-					await artifact.build(options, packemonConfig);
+					await artifact.build(options, features, packemonConfig);
 
 					artifact.state = 'passed';
 				} catch (error: unknown) {

--- a/packages/packemon/src/babel/config.ts
+++ b/packages/packemon/src/babel/config.ts
@@ -119,7 +119,7 @@ export function getBabelInputConfig(
 	const presets: PluginItem[] = [];
 	const tsOptions = {
 		allowDeclareFields: true,
-		onlyRemoveTypeImports: true,
+		onlyRemoveTypeImports: false,
 		optimizeConstEnums: true,
 	};
 

--- a/packages/packemon/tests/Artifact.test.ts
+++ b/packages/packemon/tests/Artifact.test.ts
@@ -336,7 +336,7 @@ describe('Artifact', () => {
 		it('adds exports based on input file and output name', () => {
 			artifact.builds.push({ format: 'lib' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						types: undefined,
@@ -351,7 +351,7 @@ describe('Artifact', () => {
 			artifact.sharedLib = true;
 			artifact.builds.push({ format: 'lib' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						types: undefined,
@@ -366,7 +366,7 @@ describe('Artifact', () => {
 			artifact.inputs = { sub: './src/sub.ts' };
 			artifact.builds.push({ format: 'lib' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'./sub': {
 					node: {
 						types: undefined,
@@ -380,7 +380,7 @@ describe('Artifact', () => {
 		it('supports conditional exports when there are multiple builds', () => {
 			artifact.builds.push({ format: 'lib' }, { format: 'mjs' }, { format: 'cjs' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						import: {
@@ -404,7 +404,7 @@ describe('Artifact', () => {
 				{ declaration: true, format: 'cjs' },
 			);
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						import: {
@@ -425,7 +425,7 @@ describe('Artifact', () => {
 			artifact.inputs = { sub: './src/sub.ts' };
 			artifact.builds.push({ format: 'mjs' }, { format: 'cjs' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'./sub': {
 					node: {
 						import: {
@@ -445,7 +445,7 @@ describe('Artifact', () => {
 			artifact.platform = 'browser';
 			artifact.builds.push({ format: 'lib' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					browser: {
 						types: undefined,
@@ -460,7 +460,7 @@ describe('Artifact', () => {
 			artifact.platform = 'native';
 			artifact.builds.push({ format: 'lib' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					'react-native': {
 						default: './lib/index.js',
@@ -473,7 +473,7 @@ describe('Artifact', () => {
 		it('supports lib', () => {
 			artifact.builds.push({ format: 'lib' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						types: undefined,
@@ -487,7 +487,7 @@ describe('Artifact', () => {
 		it('supports lib with types', () => {
 			artifact.builds.push({ declaration: true, format: 'lib' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						types: './lib/index.d.ts',
@@ -501,7 +501,7 @@ describe('Artifact', () => {
 		it('supports cjs', () => {
 			artifact.builds.push({ format: 'cjs' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						import: './cjs/index-wrapper.mjs',
@@ -514,7 +514,7 @@ describe('Artifact', () => {
 		it('supports cjs with types', () => {
 			artifact.builds.push({ declaration: true, format: 'cjs' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						types: './cjs/index.d.ts',
@@ -529,7 +529,7 @@ describe('Artifact', () => {
 			artifact.builds.push({ declaration: true, format: 'cjs' });
 			artifact.inputs = { index: 'src/index.cts' };
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						types: './cjs/index.d.cts',
@@ -543,7 +543,7 @@ describe('Artifact', () => {
 		it('supports mjs', () => {
 			artifact.builds.push({ format: 'mjs' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						import: './mjs/index.mjs',
@@ -555,7 +555,7 @@ describe('Artifact', () => {
 		it('supports mjs with types', () => {
 			artifact.builds.push({ declaration: true, format: 'mjs' });
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						types: './mjs/index.d.ts',
@@ -569,13 +569,63 @@ describe('Artifact', () => {
 			artifact.builds.push({ declaration: true, format: 'mjs' });
 			artifact.inputs = { index: 'src/index.mts' };
 
-			expect(artifact.getPackageExports()).toEqual({
+			expect(artifact.getPackageExports({})).toEqual({
 				'.': {
 					node: {
 						types: './mjs/index.d.mts',
 						import: './mjs/index.mjs',
 					},
 				},
+			});
+		});
+
+		describe('solid', () => {
+			it('adds entry point to source code', () => {
+				artifact.builds.push({ format: 'lib' });
+
+				expect(artifact.getPackageExports({ solid: true })).toEqual({
+					'.': {
+						node: {
+							types: undefined,
+							default: './lib/index.js',
+						},
+						solid: 'src/index.ts',
+						default: './lib/index.js',
+					},
+				});
+			});
+
+			it('supports shared lib', () => {
+				artifact.sharedLib = true;
+				artifact.builds.push({ format: 'lib' });
+
+				expect(artifact.getPackageExports({ solid: true })).toEqual({
+					'.': {
+						node: {
+							types: undefined,
+							default: './lib/node/index.js',
+						},
+						solid: 'src/index.ts',
+						default: './lib/node/index.js',
+					},
+				});
+			});
+
+			it('supports types', () => {
+				artifact.platform = 'browser';
+				artifact.builds.push({ declaration: true, format: 'esm' });
+
+				expect(artifact.getPackageExports({ solid: true })).toEqual({
+					'.': {
+						browser: {
+							default: undefined,
+							import: './esm/index.js',
+							module: './esm/index.js',
+							types: './esm/index.d.ts',
+						},
+						solid: 'src/index.ts',
+					},
+				});
 			});
 		});
 	});

--- a/packages/packemon/tests/Artifact.test.ts
+++ b/packages/packemon/tests/Artifact.test.ts
@@ -589,8 +589,33 @@ describe('Artifact', () => {
 							types: undefined,
 							default: './lib/index.js',
 						},
-						solid: 'src/index.ts',
+						solid: './src/index.ts',
 						default: './lib/index.js',
+					},
+				});
+			});
+
+			it('supports non-bundle', () => {
+				artifact.api = 'public';
+				artifact.bundle = false;
+				artifact.builds.push({ format: 'lib' });
+
+				expect(artifact.getPackageExports({ solid: true })).toEqual({
+					'.': {
+						node: {
+							types: undefined,
+							default: './lib/index.js',
+						},
+						solid: './src/index.ts',
+						default: './lib/index.js',
+					},
+					'./*': {
+						node: {
+							types: undefined,
+							default: './lib/*.js',
+						},
+						solid: './src/*.js',
+						default: './lib/*.js',
 					},
 				});
 			});
@@ -605,7 +630,7 @@ describe('Artifact', () => {
 							types: undefined,
 							default: './lib/node/index.js',
 						},
-						solid: 'src/index.ts',
+						solid: './src/index.ts',
 						default: './lib/node/index.js',
 					},
 				});
@@ -623,7 +648,7 @@ describe('Artifact', () => {
 							module: './esm/index.js',
 							types: './esm/index.d.ts',
 						},
-						solid: 'src/index.ts',
+						solid: './src/index.ts',
 					},
 				});
 			});

--- a/packages/packemon/tests/Artifact.test.ts
+++ b/packages/packemon/tests/Artifact.test.ts
@@ -504,14 +504,8 @@ describe('Artifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'.': {
 					node: {
-						import: {
-							types: undefined,
-							default: './cjs/index-wrapper.mjs',
-						},
-						require: {
-							types: undefined,
-							default: './cjs/index.cjs',
-						},
+						import: './cjs/index-wrapper.mjs',
+						require: './cjs/index.cjs',
 					},
 				},
 			});
@@ -523,14 +517,9 @@ describe('Artifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'.': {
 					node: {
-						import: {
-							types: './cjs/index.d.ts',
-							default: './cjs/index-wrapper.mjs',
-						},
-						require: {
-							types: './cjs/index.d.ts',
-							default: './cjs/index.cjs',
-						},
+						types: './cjs/index.d.ts',
+						import: './cjs/index-wrapper.mjs',
+						require: './cjs/index.cjs',
 					},
 				},
 			});
@@ -543,14 +532,9 @@ describe('Artifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'.': {
 					node: {
-						import: {
-							types: './cjs/index.d.cts',
-							default: './cjs/index-wrapper.mjs',
-						},
-						require: {
-							types: './cjs/index.d.cts',
-							default: './cjs/index.cjs',
-						},
+						types: './cjs/index.d.cts',
+						import: './cjs/index-wrapper.mjs',
+						require: './cjs/index.cjs',
 					},
 				},
 			});
@@ -562,11 +546,7 @@ describe('Artifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'.': {
 					node: {
-						import: {
-							types: undefined,
-							default: './mjs/index.mjs',
-						},
-						require: undefined,
+						import: './mjs/index.mjs',
 					},
 				},
 			});
@@ -578,11 +558,8 @@ describe('Artifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'.': {
 					node: {
-						import: {
-							types: './mjs/index.d.ts',
-							default: './mjs/index.mjs',
-						},
-						require: undefined,
+						types: './mjs/index.d.ts',
+						import: './mjs/index.mjs',
 					},
 				},
 			});
@@ -595,11 +572,8 @@ describe('Artifact', () => {
 			expect(artifact.getPackageExports()).toEqual({
 				'.': {
 					node: {
-						import: {
-							types: './mjs/index.d.mts',
-							default: './mjs/index.mjs',
-						},
-						require: undefined,
+						types: './mjs/index.d.mts',
+						import: './mjs/index.mjs',
 					},
 				},
 			});

--- a/packages/packemon/tests/Artifact.test.ts
+++ b/packages/packemon/tests/Artifact.test.ts
@@ -54,7 +54,7 @@ describe('Artifact', () => {
 			const codeSpy = jest.spyOn(artifact, 'buildCode').mockImplementation();
 			const typesSpy = jest.spyOn(artifact, 'buildTypes').mockImplementation();
 
-			await artifact.build({}, {});
+			await artifact.build({}, {}, {});
 
 			expect(codeSpy).toHaveBeenCalled();
 			expect(typesSpy).toHaveBeenCalled();

--- a/packages/packemon/tests/Package.test.ts
+++ b/packages/packemon/tests/Package.test.ts
@@ -75,9 +75,9 @@ describe('Packemon', () => {
 
 			await pkg.build({ concurrency: 1 }, config);
 
-			expect(aSpy).toHaveBeenCalledWith({ concurrency: 1 }, expect.any(Object));
-			expect(bSpy).toHaveBeenCalledWith({ concurrency: 1 }, expect.any(Object));
-			expect(cSpy).toHaveBeenCalledWith({ concurrency: 1 }, expect.any(Object));
+			expect(aSpy).toHaveBeenCalledWith({ concurrency: 1 }, expect.any(Object), expect.any(Object));
+			expect(bSpy).toHaveBeenCalledWith({ concurrency: 1 }, expect.any(Object), expect.any(Object));
+			expect(cSpy).toHaveBeenCalledWith({ concurrency: 1 }, expect.any(Object), expect.any(Object));
 		});
 
 		it('sets passed state and result time', async () => {

--- a/packages/packemon/tests/babel/__snapshots__/config.test.ts.snap
+++ b/packages/packemon/tests/babel/__snapshots__/config.test.ts.snap
@@ -116,7 +116,7 @@ exports[`getBabelInputConfig() includes typescript decorators if \`typescript\` 
       "@babel/plugin-transform-typescript",
       {
         "allowDeclareFields": true,
-        "onlyRemoveTypeImports": true,
+        "onlyRemoveTypeImports": false,
         "optimizeConstEnums": true,
       },
     ],
@@ -150,7 +150,7 @@ exports[`getBabelInputConfig() includes typescript decorators if \`typescript\` 
       "@babel/preset-typescript",
       {
         "allowDeclareFields": true,
-        "onlyRemoveTypeImports": true,
+        "onlyRemoveTypeImports": false,
         "optimizeConstEnums": true,
       },
     ],
@@ -164,7 +164,7 @@ exports[`getBabelInputConfig() includes typescript preset if \`typescript\` feat
     "@babel/preset-typescript",
     {
       "allowDeclareFields": true,
-      "onlyRemoveTypeImports": true,
+      "onlyRemoveTypeImports": false,
       "optimizeConstEnums": true,
     },
   ],
@@ -188,7 +188,7 @@ exports[`getBabelInputConfig() supports private properties with decorators if de
       "@babel/plugin-transform-typescript",
       {
         "allowDeclareFields": true,
-        "onlyRemoveTypeImports": true,
+        "onlyRemoveTypeImports": false,
         "optimizeConstEnums": true,
       },
     ],
@@ -222,7 +222,7 @@ exports[`getBabelInputConfig() supports private properties with decorators if de
       "@babel/preset-typescript",
       {
         "allowDeclareFields": true,
-        "onlyRemoveTypeImports": true,
+        "onlyRemoveTypeImports": false,
         "optimizeConstEnums": true,
       },
     ],


### PR DESCRIPTION
SolidJS supports a special `solid` package exports, so it can properly handle SSR and non-SSR scenarios. Packemon will now automate the inclusion of this export if Solid has been detected, which will point to the source files.