### PR TITLE
fix: folder path for declarations to omit platform name

### DIFF
--- a/packages/packemon/src/Artifact.ts
+++ b/packages/packemon/src/Artifact.ts
@@ -226,6 +226,9 @@ export class Artifact {
 		}
 
 		const folder = format === 'lib' && this.sharedLib ? `lib/${this.platform}` : format;
+		// Folder path for declarations cannot have the platform subpath, since multiple builds can 
+		// share the same tsconfig
+		const declFolder = format;
 		const entryExt = format === 'cjs' || format === 'mjs' ? format : 'js';
 		let declExt: string | undefined;
 
@@ -242,7 +245,7 @@ export class Artifact {
 		return {
 			declExt,
 			declPath: declExt
-				? `./${new VirtualPath(folder, `${inputPath ?? outputPath}.${declExt}`)}`
+				? `./${new VirtualPath(declFolder, `${inputPath ?? outputPath}.${declExt}`)}`
 				: undefined,
 			entryExt,
 			entryPath: `./${new VirtualPath(folder, `${outputPath}.${entryExt}`)}`,

--- a/packages/packemon/src/Artifact.ts
+++ b/packages/packemon/src/Artifact.ts
@@ -226,7 +226,7 @@ export class Artifact {
 		}
 
 		const folder = format === 'lib' && this.sharedLib ? `lib/${this.platform}` : format;
-		// Folder path for declarations cannot have the platform subpath, since multiple builds can 
+		// Folder path for declarations cannot have the platform subpath, since multiple builds can
 		// share the same tsconfig
 		const declFolder = format;
 		const entryExt = format === 'cjs' || format === 'mjs' ? format : 'js';


### PR DESCRIPTION
If there are multiple builds for different platforms with the same format, like for example:
```
"packemon": [
    {
      "bundle": true,
      "format": "esm",
      "platform": "browser",
      "inputs": {
        "web": "src/web/index.tsx"
      }
    },
    {
      "bundle": true,
      "format": "lib",
      "platform": "native",
      "inputs": {
        "mobile": "src/mobile/index.tsx"
      }
    },
    {
      "bundle": true,
      "format": "lib",
      "platform": "node",
      "inputs": {
        "web": "src/web/index.tsx"
      }
    }
  ],
```

Then a single `tsconfig.lib.json` will be generated with an `outDir` of `lib`, so the built types will exist at `lib/web/index.d.ts` and `lib/mobile/index.d.ts` and not at the nested platform paths like `lib/node/web/index.d.ts` etc. So the fix is to set the declFolder to always = format;