### PR TITLE
fix: types not added to export map for tsx input files

### DIFF
--- a/packages/packemon/src/Artifact.ts
+++ b/packages/packemon/src/Artifact.ts
@@ -226,6 +226,9 @@ export class Artifact {
 		}
 
 		const folder = format === 'lib' && this.sharedLib ? `lib/${this.platform}` : format;
+		// Folder path for declarations cannot have the platform subpath, since multiple builds can 
+		// share the same tsconfig
+		const declFolder = format;
 		const entryExt = format === 'cjs' || format === 'mjs' ? format : 'js';
 		let declExt: string | undefined;
 
@@ -242,7 +245,7 @@ export class Artifact {
 		return {
 			declExt,
 			declPath: declExt
-				? `./${new VirtualPath(folder, `${inputPath ?? outputPath}.${declExt}`)}`
+				? `./${new VirtualPath(declFolder, `${inputPath ?? outputPath}.${declExt}`)}`
 				: undefined,
 			entryExt,
 			entryPath: `./${new VirtualPath(folder, `${outputPath}.${entryExt}`)}`,

--- a/packages/packemon/src/Artifact.ts
+++ b/packages/packemon/src/Artifact.ts
@@ -226,7 +226,7 @@ export class Artifact {
 		}
 
 		const folder = format === 'lib' && this.sharedLib ? `lib/${this.platform}` : format;
-		// Folder path for declarations cannot have the platform subpath, since multiple builds can 
+		// Folder path for declarations cannot have the platform subpath, since multiple builds can
 		// share the same tsconfig
 		const declFolder = format;
 		const entryExt = format === 'cjs' || format === 'mjs' ? format : 'js';

--- a/packages/packemon/src/Artifact.ts
+++ b/packages/packemon/src/Artifact.ts
@@ -233,7 +233,7 @@ export class Artifact {
 		let declExt: string | undefined;
 
 		if (declaration) {
-			if (!inputFile || inputFile.endsWith('.ts')) {
+			if (!inputFile || /\.tsx?$/.test(inputFile)) {
 				declExt = 'd.ts';
 			} else if (inputFile.endsWith('.cts')) {
 				declExt = 'd.cts';


### PR DESCRIPTION
Added on top of https://github.com/milesj/packemon/pull/195 to just add the tsx file support 

https://github.com/milesj/packemon/issues/197