### PR TITLE
new: Support package-level features, starting with `helpers` and `swc`.

### DIFF
--- a/packages/packemon/package.json
+++ b/packages/packemon/package.json
@@ -63,7 +63,9 @@
   },
   "dependencies": {
     "@babel/core": "^7.22.5",
+    "@babel/plugin-external-helpers": "^7.22.5",
     "@babel/plugin-proposal-decorators": "^7.22.5",
+    "@babel/plugin-transform-runtime": "^7.22.5",
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-flow": "^7.22.5",
     "@babel/preset-react": "^7.22.5",
@@ -80,6 +82,7 @@
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@swc/core": "^1.3.64",
+    "@swc/helpers": "^0.5.1",
     "babel-plugin-cjs-esm-interop": "^3.0.1",
     "babel-plugin-conditional-invariant": "^3.0.1",
     "babel-plugin-env-constants": "^3.0.1",

--- a/packages/packemon/src/Artifact.ts
+++ b/packages/packemon/src/Artifact.ts
@@ -20,6 +20,7 @@ import type {
 	InputMap,
 	PackageExportPaths,
 	PackageExports,
+	PackemonPackageFeatures,
 	Platform,
 	Support,
 } from './types';
@@ -40,6 +41,9 @@ export class Artifact {
 
 	// List of custom Rollup externals
 	externals: string[] = [];
+
+	// Features unique to this artifact
+	features: PackemonPackageFeatures = {};
 
 	// Mapping of output names to input paths
 	inputs: InputMap = {};

--- a/packages/packemon/src/Package.ts
+++ b/packages/packemon/src/Package.ts
@@ -204,6 +204,7 @@ export class Package {
 			artifact.bundle = config.bundle;
 			artifact.configGroup = index;
 			artifact.externals = config.externals;
+			artifact.features = config.features;
 			artifact.inputs = config.inputs;
 			artifact.namespace = config.namespace;
 			artifact.platform = config.platform;
@@ -370,6 +371,7 @@ export class Package {
 					api,
 					bundle,
 					externals: toArray(config.externals),
+					features: config.features,
 					formats,
 					inputs: config.inputs,
 					namespace: config.namespace,

--- a/packages/packemon/src/babel.ts
+++ b/packages/packemon/src/babel.ts
@@ -20,13 +20,7 @@ const support = (process.env.PACKEMON_SUPPORT ?? DEFAULT_SUPPORT) as Support;
 
 function getBabelConfig(artifact: Artifact, featureFlags: FeatureFlags): ConfigStructure {
 	const inputConfig = getBabelInputConfig(artifact, featureFlags, {});
-	const outputConfig = getBabelOutputConfig(
-		artifact.platform,
-		artifact.support,
-		artifact.builds[0].format,
-		featureFlags,
-		{},
-	);
+	const outputConfig = getBabelOutputConfig(artifact, artifact.builds[0].format, featureFlags, {});
 
 	return {
 		// Input must come first

--- a/packages/packemon/src/babel.ts
+++ b/packages/packemon/src/babel.ts
@@ -20,7 +20,13 @@ const support = (process.env.PACKEMON_SUPPORT ?? DEFAULT_SUPPORT) as Support;
 
 function getBabelConfig(artifact: Artifact, featureFlags: FeatureFlags): ConfigStructure {
 	const inputConfig = getBabelInputConfig(artifact, featureFlags, {});
-	const outputConfig = getBabelOutputConfig(artifact, artifact.builds[0].format, featureFlags, {});
+	const outputConfig = getBabelOutputConfig(
+		artifact.platform,
+		artifact.support,
+		artifact.builds[0].format,
+		featureFlags,
+		{},
+	);
 
 	return {
 		// Input must come first

--- a/packages/packemon/src/rollup/config.ts
+++ b/packages/packemon/src/rollup/config.ts
@@ -81,6 +81,7 @@ export function getRollupExternals(artifact: Artifact) {
 	};
 }
 
+// eslint-disable-next-line complexity
 export function getRollupOutputConfig(
 	artifact: Artifact,
 	features: FeatureFlags,
@@ -90,7 +91,7 @@ export function getRollupOutputConfig(
 	const { platform, support } = artifact;
 	const { entryExt, folder } = artifact.getBuildOutput(format, 'index');
 	// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-	const isSwc = packemonConfig.swc || !!process.env.PACKEMON_SWC;
+	const isSwc = packemonConfig.swc || artifact.features.swc || !!process.env.PACKEMON_SWC;
 	const isEsm = format === 'esm' || format === 'mjs';
 
 	const output: OutputOptions = {

--- a/packages/packemon/src/rollup/config.ts
+++ b/packages/packemon/src/rollup/config.ts
@@ -123,13 +123,13 @@ export function getRollupOutputConfig(
 			preserveDynamicImport(platform, support),
 			isSwc
 				? swcOutput({
-						...getSwcOutputConfig(artifact, format, features, packemonConfig),
+						...getSwcOutputConfig(platform, support, format, features, packemonConfig),
 						filename: artifact.package.path.path(),
 						// Maps were extracted before transformation
 						sourceMaps: false,
 				  })
 				: getBabelOutputPlugin({
-						...getBabelOutputConfig(artifact, format, features, packemonConfig),
+						...getBabelOutputConfig(platform, support, format, features, packemonConfig),
 						filename: artifact.package.path.path(),
 						// Provide a custom name for the UMD global
 						moduleId: format === 'umd' ? artifact.namespace : undefined,
@@ -212,7 +212,7 @@ export async function getRollupConfig(
 						exclude: isTest ? [] : EXCLUDE,
 						extensions: EXTENSIONS,
 						filename: artifact.package.path.path(),
-						skipPreflightCheck: !isTest,
+						skipPreflightCheck: true,
 						// Extract maps from the original source
 						sourceMaps: !isNode,
 				  }),

--- a/packages/packemon/src/rollup/config.ts
+++ b/packages/packemon/src/rollup/config.ts
@@ -203,7 +203,7 @@ export async function getRollupConfig(
 				  })
 				: getBabelInputPlugin({
 						...getBabelInputConfig(artifact, features, packemonConfig),
-						babelHelpers: 'bundled',
+						babelHelpers: artifact.features.babelHelpers ?? 'bundled',
 						exclude: isTest ? [] : EXCLUDE,
 						extensions: EXTENSIONS,
 						filename: artifact.package.path.path(),

--- a/packages/packemon/src/schemas.ts
+++ b/packages/packemon/src/schemas.ts
@@ -20,12 +20,13 @@ import {
 	NativeFormat,
 	NodeFormat,
 	PackemonPackageConfig,
+	PackemonPackageFeatures,
 	Platform,
 	Support,
 	ValidateOptions,
 } from './types';
 
-const { array, bool, number, object, string, union } = schemas;
+const { array, bool, number, object, shape, string, union } = schemas;
 
 // PLATFORMS
 
@@ -64,10 +65,20 @@ const support = string<Support>(DEFAULT_SUPPORT).oneOf(SUPPORTS);
 
 // BLUEPRINTS
 
+export const packemonFeaturesBlueprint: Blueprint<PackemonPackageFeatures> = {
+	babelHelpers: string('bundled').oneOf<NonNullable<PackemonPackageFeatures['babelHelpers']>>([
+		'bundled',
+		'external',
+		'inline',
+		'runtime',
+	]),
+};
+
 export const packemonBlueprint: Blueprint<PackemonPackageConfig> = {
 	api: string('private').oneOf<ApiType>(['public', 'private']),
 	bundle: bool(true),
 	externals: union([]).of([string(), array().of(string())]),
+	features: shape(packemonFeaturesBlueprint),
 	format: union(undefined)
 		.of([format, array().of(format)])
 		.undefinable(),

--- a/packages/packemon/src/schemas.ts
+++ b/packages/packemon/src/schemas.ts
@@ -72,6 +72,7 @@ export const packemonFeaturesBlueprint: Blueprint<PackemonPackageFeatures> = {
 		'inline',
 		'runtime',
 	]),
+	swc: bool(),
 };
 
 export const packemonBlueprint: Blueprint<PackemonPackageConfig> = {

--- a/packages/packemon/src/schemas.ts
+++ b/packages/packemon/src/schemas.ts
@@ -66,7 +66,7 @@ const support = string<Support>(DEFAULT_SUPPORT).oneOf(SUPPORTS);
 // BLUEPRINTS
 
 export const packemonFeaturesBlueprint: Blueprint<PackemonPackageFeatures> = {
-	babelHelpers: string('bundled').oneOf<NonNullable<PackemonPackageFeatures['babelHelpers']>>([
+	helpers: string('bundled').oneOf<NonNullable<PackemonPackageFeatures['helpers']>>([
 		'bundled',
 		'external',
 		'inline',

--- a/packages/packemon/src/swc/config.ts
+++ b/packages/packemon/src/swc/config.ts
@@ -154,7 +154,8 @@ export function getSwcInputConfig(
 // The output config does all the transformation and downleveling through the preset-env.
 // This is handled per output since we need to configure based on target + format combinations.
 export function getSwcOutputConfig(
-	artifact: Artifact,
+	platform: Platform,
+	support: Support,
 	format: Format,
 	features: FeatureFlags,
 	packemonConfig: ConfigFile = {},
@@ -169,12 +170,12 @@ export function getSwcOutputConfig(
 		bugfixes: true,
 		shippedProposals: true,
 		// Platform specific
-		...getPlatformEnvOptions(artifact.platform, artifact.support, format),
+		...getPlatformEnvOptions(platform, support, format),
 	};
 
 	const module: ModuleConfig = {
 		type: getModuleConfigType(format),
-		ignoreDynamic: shouldKeepDynamicImport(artifact.platform, artifact.support),
+		ignoreDynamic: shouldKeepDynamicImport(platform, support),
 	};
 
 	// This is to trick the Babel plugin to not transform the const
@@ -199,7 +200,7 @@ export function getSwcOutputConfig(
 					},
 				},
 			},
-			target: SUPPORT_TO_ESM_SPEC[artifact.support],
+			target: SUPPORT_TO_ESM_SPEC[support],
 		},
 	};
 
@@ -209,8 +210,8 @@ export function getSwcOutputConfig(
 	packemonConfig.swcOutput?.(config, {
 		features,
 		format,
-		platform: artifact.platform,
-		support: artifact.support,
+		platform,
+		support,
 	});
 
 	return config;

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -66,6 +66,7 @@ export type InputMap = Record<string, string>;
 
 export interface PackemonPackageFeatures {
 	babelHelpers?: 'bundled' | 'external' | 'inline' | 'runtime';
+	swc?: boolean;
 }
 
 export interface PackemonPackageConfig {

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -65,7 +65,7 @@ export type ApiType = 'private' | 'public';
 export type InputMap = Record<string, string>;
 
 export interface PackemonPackageFeatures {
-	babelHelpers?: 'bundled' | 'external' | 'inline' | 'runtime';
+	helpers?: 'bundled' | 'external' | 'inline' | 'runtime';
 	swc?: boolean;
 }
 

--- a/packages/packemon/src/types.ts
+++ b/packages/packemon/src/types.ts
@@ -64,10 +64,15 @@ export type ApiType = 'private' | 'public';
 
 export type InputMap = Record<string, string>;
 
+export interface PackemonPackageFeatures {
+	babelHelpers?: 'bundled' | 'external' | 'inline' | 'runtime';
+}
+
 export interface PackemonPackageConfig {
 	api?: ApiType;
 	bundle?: boolean;
 	externals?: string[] | string;
+	features?: PackemonPackageFeatures;
 	format?: Format | Format[];
 	inputs?: InputMap;
 	namespace?: string;
@@ -84,6 +89,7 @@ export interface PackageConfig {
 	api: ApiType;
 	bundle: boolean;
 	externals: string[];
+	features: PackemonPackageFeatures;
 	formats: Format[];
 	inputs: InputMap;
 	namespace: string;

--- a/packages/packemon/tests/Package.test.ts
+++ b/packages/packemon/tests/Package.test.ts
@@ -1214,7 +1214,7 @@ describe('Package', () => {
 
 	describe('setConfigs()', () => {
 		const COMMON_FEATURES = {
-			babelHelpers: 'bundled',
+			helpers: 'bundled',
 			swc: false,
 		};
 
@@ -1484,7 +1484,7 @@ describe('Package', () => {
 					externals: [],
 					features: {
 						...COMMON_FEATURES,
-						babelHelpers: 'runtime',
+						helpers: 'runtime',
 					},
 					formats: ['esm'],
 					inputs: { index: 'src/index.ts' },

--- a/packages/packemon/tests/Package.test.ts
+++ b/packages/packemon/tests/Package.test.ts
@@ -1461,7 +1461,7 @@ describe('Package', () => {
 					bundle: false,
 					platform: 'browser',
 					features: {
-						babelHelpers: 'runtime',
+						helpers: 'runtime',
 					},
 				},
 			]);

--- a/packages/packemon/tests/Package.test.ts
+++ b/packages/packemon/tests/Package.test.ts
@@ -1213,6 +1213,10 @@ describe('Package', () => {
 	});
 
 	describe('setConfigs()', () => {
+		const COMMON_FEATURES = {
+			babelHelpers: 'bundled',
+		};
+
 		beforeEach(() => {
 			pkg = loadPackageAtPath(getFixturePath('workspaces-feature-flags', 'packages/common'));
 			// @ts-expect-error Allow override
@@ -1236,6 +1240,7 @@ describe('Package', () => {
 					api: 'private',
 					bundle: true,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['esm'],
 					inputs: {},
 					platform: 'browser',
@@ -1262,6 +1267,7 @@ describe('Package', () => {
 					api: 'private',
 					bundle: true,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['esm', 'umd'],
 					inputs: {},
 					platform: 'browser',
@@ -1288,6 +1294,7 @@ describe('Package', () => {
 					api: 'private',
 					bundle: true,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['lib'],
 					inputs: {},
 					platform: 'native',
@@ -1314,6 +1321,7 @@ describe('Package', () => {
 					api: 'public',
 					bundle: false,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['mjs'],
 					inputs: {},
 					platform: 'node',
@@ -1339,6 +1347,7 @@ describe('Package', () => {
 					api: 'public',
 					bundle: false,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['mjs'],
 					inputs: {},
 					platform: 'node',
@@ -1361,6 +1370,7 @@ describe('Package', () => {
 					api: 'private',
 					bundle: true,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['esm'],
 					inputs: {},
 					platform: 'browser',
@@ -1371,6 +1381,7 @@ describe('Package', () => {
 					api: 'public',
 					bundle: false,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['mjs'],
 					inputs: {},
 					platform: 'node',
@@ -1405,6 +1416,7 @@ describe('Package', () => {
 					api: 'private',
 					bundle: true,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['esm'],
 					inputs: {},
 					platform: 'browser',
@@ -1415,6 +1427,7 @@ describe('Package', () => {
 					api: 'public',
 					bundle: false,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['mjs'],
 					inputs: {},
 					platform: 'node',
@@ -1425,6 +1438,7 @@ describe('Package', () => {
 					api: 'private',
 					bundle: true,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['lib'],
 					inputs: {},
 					platform: 'native',
@@ -1445,6 +1459,9 @@ describe('Package', () => {
 					api: 'public',
 					bundle: false,
 					platform: 'browser',
+					features: {
+						babelHelpers: 'runtime',
+					},
 				},
 			]);
 
@@ -1453,6 +1470,7 @@ describe('Package', () => {
 					api: 'private',
 					bundle: true,
 					externals: [],
+					features: COMMON_FEATURES,
 					formats: ['mjs'],
 					inputs: { index: 'src/index.ts' },
 					platform: 'node',
@@ -1463,6 +1481,9 @@ describe('Package', () => {
 					api: 'public',
 					bundle: false,
 					externals: [],
+					features: {
+						babelHelpers: 'runtime',
+					},
 					formats: ['esm'],
 					inputs: { index: 'src/index.ts' },
 					platform: 'browser',
@@ -1484,6 +1505,7 @@ describe('Package', () => {
 					api: 'private',
 					bundle: true,
 					externals: ['foo', 'bar'],
+					features: COMMON_FEATURES,
 					formats: ['esm'],
 					inputs: { index: 'src/index.ts' },
 					platform: 'browser',
@@ -1505,6 +1527,7 @@ describe('Package', () => {
 					api: 'private',
 					bundle: true,
 					externals: ['foo'],
+					features: COMMON_FEATURES,
 					formats: ['esm'],
 					inputs: { index: 'src/index.ts' },
 					platform: 'browser',

--- a/packages/packemon/tests/Package.test.ts
+++ b/packages/packemon/tests/Package.test.ts
@@ -1215,6 +1215,7 @@ describe('Package', () => {
 	describe('setConfigs()', () => {
 		const COMMON_FEATURES = {
 			babelHelpers: 'bundled',
+			swc: false,
 		};
 
 		beforeEach(() => {
@@ -1482,6 +1483,7 @@ describe('Package', () => {
 					bundle: false,
 					externals: [],
 					features: {
+						...COMMON_FEATURES,
 						babelHelpers: 'runtime',
 					},
 					formats: ['esm'],

--- a/packages/packemon/tests/Packemon.test.ts
+++ b/packages/packemon/tests/Packemon.test.ts
@@ -193,6 +193,9 @@ describe('Packemon', () => {
 					api: 'public',
 					bundle: false,
 					externals: [],
+					features: {
+						babelHelpers: 'bundled',
+					},
 					formats: ['mjs'],
 					inputs: { core: './src/core.ts' },
 					namespace: '',
@@ -213,6 +216,9 @@ describe('Packemon', () => {
 					api: 'public',
 					bundle: false,
 					externals: [],
+					features: {
+						babelHelpers: 'bundled',
+					},
 					formats: ['lib'],
 					inputs: { index: 'src/index.ts' },
 					namespace: '',
@@ -223,6 +229,9 @@ describe('Packemon', () => {
 					api: 'private',
 					bundle: true,
 					externals: [],
+					features: {
+						babelHelpers: 'bundled',
+					},
 					formats: ['esm'],
 					inputs: { index: 'src/index.ts' },
 					namespace: '',

--- a/packages/packemon/tests/Packemon.test.ts
+++ b/packages/packemon/tests/Packemon.test.ts
@@ -195,6 +195,7 @@ describe('Packemon', () => {
 					externals: [],
 					features: {
 						babelHelpers: 'bundled',
+						swc: false,
 					},
 					formats: ['mjs'],
 					inputs: { core: './src/core.ts' },
@@ -218,6 +219,7 @@ describe('Packemon', () => {
 					externals: [],
 					features: {
 						babelHelpers: 'bundled',
+						swc: false,
 					},
 					formats: ['lib'],
 					inputs: { index: 'src/index.ts' },
@@ -231,6 +233,7 @@ describe('Packemon', () => {
 					externals: [],
 					features: {
 						babelHelpers: 'bundled',
+						swc: false,
 					},
 					formats: ['esm'],
 					inputs: { index: 'src/index.ts' },

--- a/packages/packemon/tests/Packemon.test.ts
+++ b/packages/packemon/tests/Packemon.test.ts
@@ -194,7 +194,7 @@ describe('Packemon', () => {
 					bundle: false,
 					externals: [],
 					features: {
-						babelHelpers: 'bundled',
+						helpers: 'bundled',
 						swc: false,
 					},
 					formats: ['mjs'],
@@ -218,7 +218,7 @@ describe('Packemon', () => {
 					bundle: false,
 					externals: [],
 					features: {
-						babelHelpers: 'bundled',
+						helpers: 'bundled',
 						swc: false,
 					},
 					formats: ['lib'],
@@ -232,7 +232,7 @@ describe('Packemon', () => {
 					bundle: true,
 					externals: [],
 					features: {
-						babelHelpers: 'bundled',
+						helpers: 'bundled',
 						swc: false,
 					},
 					formats: ['esm'],

--- a/packages/packemon/tests/__snapshots__/outputs.test.ts.snap
+++ b/packages/packemon/tests/__snapshots__/outputs.test.ts.snap
@@ -1,5 +1,177 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Feature flags compiles 1`] = `
+[
+  "lib/helpers.js",
+  "'use strict';
+
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
+function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _typeof(key) === "symbol" ? key : String(key); }
+function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+var Example = /*#__PURE__*/function () {
+  function Example() {
+    _classCallCheck(this, Example);
+    _defineProperty(this, "property", 123);
+  }
+  _createClass(Example, [{
+    key: "log",
+    value: function log() {}
+  }]);
+  return Example;
+}();
+exports.Example = Example;
+//# sourceMappingURL=helpers.js.map
+",
+]
+`;
+
+exports[`Feature flags compiles 2`] = `
+[
+  "lib/helpers.js",
+  "'use strict';
+
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
+function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _typeof(key) === "symbol" ? key : String(key); }
+function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+var Example = /*#__PURE__*/function () {
+  function Example() {
+    _classCallCheck(this, Example);
+    _defineProperty(this, "property", 123);
+  }
+  _createClass(Example, [{
+    key: "log",
+    value: function log() {}
+  }]);
+  return Example;
+}();
+exports.Example = Example;
+//# sourceMappingURL=helpers.js.map
+",
+]
+`;
+
+exports[`Feature flags compiles 3`] = `
+[
+  "lib/index.js",
+  "// Bundled with Packemon: https://packemon.dev
+// Platform: browser, Support: legacy, Format: lib
+'use strict';
+function _class_call_check(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+        throw new TypeError("Cannot call a class as a function");
+    }
+}
+function _defineProperties(target, props) {
+    for(var i = 0; i < props.length; i++){
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if ("value" in descriptor) descriptor.writable = true;
+        Object.defineProperty(target, descriptor.key, descriptor);
+    }
+}
+function _create_class(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) _defineProperties(Constructor, staticProps);
+    return Constructor;
+}
+function _define_property(obj, key, value) {
+    if (key in obj) {
+        Object.defineProperty(obj, key, {
+            value: value,
+            enumerable: true,
+            configurable: true,
+            writable: true
+        });
+    } else {
+        obj[key] = value;
+    }
+    return obj;
+}
+var Example = /*#__PURE__*/ function() {
+    function Example() {
+        _class_call_check(this, Example);
+        _define_property(this, "property", 123);
+    }
+    _create_class(Example, [
+        {
+            key: "log",
+            value: function log() {}
+        }
+    ]);
+    return Example;
+}();
+exports.Example = Example;
+//# sourceMappingURL=index.js.map
+",
+]
+`;
+
+exports[`Feature flags compiles 4`] = `
+[
+  "lib/index.js",
+  "// Bundled with Packemon: https://packemon.dev
+// Platform: browser, Support: legacy, Format: lib
+'use strict';
+function _class_call_check(instance, Constructor) {
+    if (!(instance instanceof Constructor)) {
+        throw new TypeError("Cannot call a class as a function");
+    }
+}
+function _defineProperties(target, props) {
+    for(var i = 0; i < props.length; i++){
+        var descriptor = props[i];
+        descriptor.enumerable = descriptor.enumerable || false;
+        descriptor.configurable = true;
+        if ("value" in descriptor) descriptor.writable = true;
+        Object.defineProperty(target, descriptor.key, descriptor);
+    }
+}
+function _create_class(Constructor, protoProps, staticProps) {
+    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
+    if (staticProps) _defineProperties(Constructor, staticProps);
+    return Constructor;
+}
+function _define_property(obj, key, value) {
+    if (key in obj) {
+        Object.defineProperty(obj, key, {
+            value: value,
+            enumerable: true,
+            configurable: true,
+            writable: true
+        });
+    } else {
+        obj[key] = value;
+    }
+    return obj;
+}
+var Example = /*#__PURE__*/ function() {
+    function Example() {
+        _class_call_check(this, Example);
+        _define_property(this, "property", 123);
+    }
+    _create_class(Example, [
+        {
+            key: "log",
+            value: function log() {}
+        }
+    ]);
+    return Example;
+}();
+exports.Example = Example;
+//# sourceMappingURL=index.js.map
+",
+]
+`;
+
 exports[`Outputs (babel) artifacts builds all the artifacts with rollup 1`] = `
 [
   "cjs/server.cjs",

--- a/packages/packemon/tests/__snapshots__/outputs.test.ts.snap
+++ b/packages/packemon/tests/__snapshots__/outputs.test.ts.snap
@@ -6,6 +6,7 @@ exports[`Feature flags compiles 1`] = `
   "'use strict';
 
 function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+function _newArrowCheck(innerThis, boundThis) { if (innerThis !== boundThis) { throw new TypeError("Cannot instantiate an arrow function"); } }
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
@@ -14,12 +15,23 @@ function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _ty
 function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
 var Example = /*#__PURE__*/function () {
   function Example() {
+    var _this = this;
     _classCallCheck(this, Example);
     _defineProperty(this, "property", 123);
+    _defineProperty(this, "method", function () {
+      _newArrowCheck(this, _this);
+      return [].concat();
+    }.bind(this));
   }
   _createClass(Example, [{
     key: "log",
     value: function log() {}
+  }, {
+    key: "foo",
+    get: function get() {
+      return '';
+    },
+    set: function set(value) {}
   }]);
   return Example;
 }();
@@ -35,6 +47,7 @@ exports[`Feature flags compiles 2`] = `
   "'use strict';
 
 function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+function _newArrowCheck(innerThis, boundThis) { if (innerThis !== boundThis) { throw new TypeError("Cannot instantiate an arrow function"); } }
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, _toPropertyKey(descriptor.key), descriptor); } }
 function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
@@ -43,12 +56,23 @@ function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return _ty
 function _toPrimitive(input, hint) { if (_typeof(input) !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (_typeof(res) !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
 var Example = /*#__PURE__*/function () {
   function Example() {
+    var _this = this;
     _classCallCheck(this, Example);
     _defineProperty(this, "property", 123);
+    _defineProperty(this, "method", function () {
+      _newArrowCheck(this, _this);
+      return [].concat();
+    }.bind(this));
   }
   _createClass(Example, [{
     key: "log",
     value: function log() {}
+  }, {
+    key: "foo",
+    get: function get() {
+      return '';
+    },
+    set: function set(value) {}
   }]);
   return Example;
 }();
@@ -60,10 +84,16 @@ exports.Example = Example;
 
 exports[`Feature flags compiles 3`] = `
 [
-  "lib/index.js",
-  "// Bundled with Packemon: https://packemon.dev
-// Platform: browser, Support: legacy, Format: lib
-'use strict';
+  "lib/helpers.js",
+  "'use strict';
+function _array_like_to_array(arr, len) {
+    if (len == null || len > arr.length) len = arr.length;
+    for(var i = 0, arr2 = new Array(len); i < len; i++)arr2[i] = arr[i];
+    return arr2;
+}
+function _array_without_holes(arr) {
+    if (Array.isArray(arr)) return _array_like_to_array(arr);
+}
 function _class_call_check(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
         throw new TypeError("Cannot call a class as a function");
@@ -96,31 +126,64 @@ function _define_property(obj, key, value) {
     }
     return obj;
 }
+function _iterable_to_array(iter) {
+    if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+}
+function _non_iterable_spread() {
+    throw new TypeError("Invalid attempt to spread non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+}
+function _to_consumable_array(arr) {
+    return _array_without_holes(arr) || _iterable_to_array(arr) || _unsupported_iterable_to_array(arr) || _non_iterable_spread();
+}
+function _unsupported_iterable_to_array(o, minLen) {
+    if (!o) return;
+    if (typeof o === "string") return _array_like_to_array(o, minLen);
+    var n = Object.prototype.toString.call(o).slice(8, -1);
+    if (n === "Object" && o.constructor) n = o.constructor.name;
+    if (n === "Map" || n === "Set") return Array.from(n);
+    if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _array_like_to_array(o, minLen);
+}
 var Example = /*#__PURE__*/ function() {
     function Example() {
         _class_call_check(this, Example);
         _define_property(this, "property", 123);
+        _define_property(this, "method", function() {
+            return _to_consumable_array([]);
+        });
     }
     _create_class(Example, [
         {
             key: "log",
             value: function log() {}
+        },
+        {
+            key: "foo",
+            get: function get() {
+                return '';
+            },
+            set: function set(value) {}
         }
     ]);
     return Example;
 }();
 exports.Example = Example;
-//# sourceMappingURL=index.js.map
+//# sourceMappingURL=helpers.js.map
 ",
 ]
 `;
 
 exports[`Feature flags compiles 4`] = `
 [
-  "lib/index.js",
-  "// Bundled with Packemon: https://packemon.dev
-// Platform: browser, Support: legacy, Format: lib
-'use strict';
+  "lib/helpers.js",
+  "'use strict';
+function _array_like_to_array(arr, len) {
+    if (len == null || len > arr.length) len = arr.length;
+    for(var i = 0, arr2 = new Array(len); i < len; i++)arr2[i] = arr[i];
+    return arr2;
+}
+function _array_without_holes(arr) {
+    if (Array.isArray(arr)) return _array_like_to_array(arr);
+}
 function _class_call_check(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
         throw new TypeError("Cannot call a class as a function");
@@ -153,21 +216,48 @@ function _define_property(obj, key, value) {
     }
     return obj;
 }
+function _iterable_to_array(iter) {
+    if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+}
+function _non_iterable_spread() {
+    throw new TypeError("Invalid attempt to spread non-iterable instance.\\\\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+}
+function _to_consumable_array(arr) {
+    return _array_without_holes(arr) || _iterable_to_array(arr) || _unsupported_iterable_to_array(arr) || _non_iterable_spread();
+}
+function _unsupported_iterable_to_array(o, minLen) {
+    if (!o) return;
+    if (typeof o === "string") return _array_like_to_array(o, minLen);
+    var n = Object.prototype.toString.call(o).slice(8, -1);
+    if (n === "Object" && o.constructor) n = o.constructor.name;
+    if (n === "Map" || n === "Set") return Array.from(n);
+    if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _array_like_to_array(o, minLen);
+}
 var Example = /*#__PURE__*/ function() {
     function Example() {
         _class_call_check(this, Example);
         _define_property(this, "property", 123);
+        _define_property(this, "method", function() {
+            return _to_consumable_array([]);
+        });
     }
     _create_class(Example, [
         {
             key: "log",
             value: function log() {}
+        },
+        {
+            key: "foo",
+            get: function get() {
+                return '';
+            },
+            set: function set(value) {}
         }
     ]);
     return Example;
 }();
 exports.Example = Example;
-//# sourceMappingURL=index.js.map
+//# sourceMappingURL=helpers.js.map
 ",
 ]
 `;

--- a/packages/packemon/tests/babel/config.test.ts
+++ b/packages/packemon/tests/babel/config.test.ts
@@ -13,6 +13,7 @@ const SUPPORTS: Support[] = ['legacy', 'stable', 'current', 'experimental'];
 
 describe('getBabelInputConfig()', () => {
 	const bundleArtifact: any = {
+		features: {},
 		package: { hasDependency: () => false },
 	};
 

--- a/packages/packemon/tests/outputs.test.ts
+++ b/packages/packemon/tests/outputs.test.ts
@@ -254,7 +254,7 @@ describe('Feature flags', () => {
 		pkg.artifacts.push(babelExternal);
 
 		const swc = new Artifact(pkg, [{ format: 'lib' }]);
-		swc.bundle = true;
+		swc.bundle = false;
 		swc.platform = 'browser';
 		swc.support = 'legacy';
 		swc.inputs = { index: 'src/helpers.ts' };
@@ -263,7 +263,7 @@ describe('Feature flags', () => {
 		pkg.artifacts.push(swc);
 
 		const swcExternal = new Artifact(pkg, [{ format: 'lib' }]);
-		swcExternal.bundle = true;
+		swcExternal.bundle = false;
 		swcExternal.platform = 'browser';
 		swcExternal.support = 'legacy';
 		swcExternal.inputs = { index: 'src/helpers.ts' };

--- a/packages/packemon/tests/outputs.test.ts
+++ b/packages/packemon/tests/outputs.test.ts
@@ -232,7 +232,7 @@ describe('Feature flags', () => {
 	const root = new Path(getFixturePath('features'));
 	const snapshots = createSnapshotSpies(root, true);
 
-	it.only('compiles', async () => {
+	it('compiles', async () => {
 		const pkg = loadPackageAtPath(root);
 
 		const babelRuntime = new Artifact(pkg, [{ format: 'lib' }]);

--- a/packages/packemon/tests/outputs.test.ts
+++ b/packages/packemon/tests/outputs.test.ts
@@ -227,3 +227,57 @@ describe('Special formats', () => {
 		});
 	});
 });
+
+describe('Feature flags', () => {
+	const root = new Path(getFixturePath('features'));
+	const snapshots = createSnapshotSpies(root, true);
+
+	it.only('compiles', async () => {
+		const pkg = loadPackageAtPath(root);
+
+		const babelRuntime = new Artifact(pkg, [{ format: 'lib' }]);
+		babelRuntime.bundle = false;
+		babelRuntime.platform = 'browser';
+		babelRuntime.support = 'legacy';
+		babelRuntime.inputs = { index: 'src/helpers.ts' };
+		babelRuntime.features = { helpers: 'runtime' };
+
+		pkg.artifacts.push(babelRuntime);
+
+		const babelExternal = new Artifact(pkg, [{ format: 'lib' }]);
+		babelExternal.bundle = false;
+		babelExternal.platform = 'browser';
+		babelExternal.support = 'legacy';
+		babelExternal.inputs = { index: 'src/helpers.ts' };
+		babelExternal.features = { helpers: 'external' };
+
+		pkg.artifacts.push(babelExternal);
+
+		const swc = new Artifact(pkg, [{ format: 'lib' }]);
+		swc.bundle = true;
+		swc.platform = 'browser';
+		swc.support = 'legacy';
+		swc.inputs = { index: 'src/helpers.ts' };
+		swc.features = { swc: true };
+
+		pkg.artifacts.push(swc);
+
+		const swcExternal = new Artifact(pkg, [{ format: 'lib' }]);
+		swcExternal.bundle = true;
+		swcExternal.platform = 'browser';
+		swcExternal.support = 'legacy';
+		swcExternal.inputs = { index: 'src/helpers.ts' };
+		swcExternal.features = { swc: true, helpers: 'external' };
+
+		pkg.artifacts.push(swcExternal);
+
+		await pkg.build({}, {});
+
+		snapshots(pkg).forEach((ss) => {
+			// eslint-disable-next-line jest/no-conditional-in-test
+			if (ss[0].endsWith('.js')) {
+				expect(ss).toMatchSnapshot();
+			}
+		});
+	});
+});

--- a/packages/packemon/tests/swc/config.test.ts
+++ b/packages/packemon/tests/swc/config.test.ts
@@ -7,6 +7,7 @@ const SUPPORTS: Support[] = ['legacy', 'stable', 'current', 'experimental'];
 
 describe('getSwcInputConfig()', () => {
 	const bundleArtifact: any = {
+		features: {},
 		package: { hasDependency: () => false },
 	};
 

--- a/tests/__fixtures__/features/package.json
+++ b/tests/__fixtures__/features/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "features",
+  "packemon": {}
+}

--- a/tests/__fixtures__/features/src/helpers.ts
+++ b/tests/__fixtures__/features/src/helpers.ts
@@ -1,4 +1,11 @@
 export class Example {
 	property = 123;
 	log() {}
+	method = () => {
+		return [...[]];
+	};
+	get foo() {
+		return '';
+	}
+	set foo(value) {}
 }

--- a/tests/__fixtures__/features/src/helpers.ts
+++ b/tests/__fixtures__/features/src/helpers.ts
@@ -1,0 +1,4 @@
+export class Example {
+	property = 123;
+	log() {}
+}

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -172,6 +172,23 @@ need to configure this.
 > These inputs can be automatically mapped to `package.json` `exports` using the `--addExports` CLI
 > option. Do note that this feature is still experimental.
 
+## Features
+
+Feature flags can be enabled on a per-package basis, providing far more granular control, and
+providing an opt-in mechanism for experimental features. The following features are available:
+
+- `babelHelpers` (`string`) - How Babel helpers should be handled when transpiling. Accepts
+  `bundled` (default), `external`, `runtime`, or `inline`.
+- `swc` (`bool`) - Transpile source files with [swc](./swc) instead of Babel. Defaults to `false`.
+
+```json
+{
+  "features": {
+    "babelHelpers": "runtime"
+  }
+}
+```
+
 ## Externals
 
 By default, Packemon will denote all `package.json` dependencies (peer, dev, and prod) as Rollup

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -177,14 +177,14 @@ need to configure this.
 Feature flags can be enabled on a per-package basis, providing far more granular control, and
 providing an opt-in mechanism for experimental features. The following features are available:
 
-- `babelHelpers` (`string`) - How Babel helpers should be handled when transpiling. Accepts
-  `bundled` (default), `external`, `runtime`, or `inline`.
+- `helpers` (`string`) - How Babel/swc helpers should be handled when transpiling. Accepts `bundled`
+  (default), `external`, `runtime`, or `inline`.
 - `swc` (`bool`) - Transpile source files with [swc](./swc) instead of Babel. Defaults to `false`.
 
 ```json
 {
   "features": {
-    "babelHelpers": "runtime"
+    "helpers": "runtime"
   }
 }
 ```

--- a/website/docs/swc.md
+++ b/website/docs/swc.md
@@ -7,12 +7,25 @@ replacement for Babel. If you want improved performance for less features, we su
 
 ## Enabling swc
 
-There are 3 ways to enable swc:
+There are 4 ways to enable swc:
 
 Define the `PACKEMON_SWC` environment variable.
 
 ```shell
 PACKEMON_SWC=true packemon build
+```
+
+Enable the `swc` [feature flag](./config#features).
+
+```json title="package.json"
+{
+  // ...
+  "packemon": {
+    "features": {
+      "swc": true
+    }
+  }
+}
 ```
 
 Enable for all packages through a root `packemon.config.{js,ts}` (requires

--- a/yarn.lock
+++ b/yarn.lock
@@ -349,22 +349,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-define-polyfill-provider@npm:^0.3.1, @babel/helper-define-polyfill-provider@npm:^0.3.2, @babel/helper-define-polyfill-provider@npm:^0.3.3":
-  version: 0.3.3
-  resolution: "@babel/helper-define-polyfill-provider@npm:0.3.3"
-  dependencies:
-    "@babel/helper-compilation-targets": ^7.17.7
-    "@babel/helper-plugin-utils": ^7.16.7
-    debug: ^4.1.1
-    lodash.debounce: ^4.0.8
-    resolve: ^1.14.2
-    semver: ^6.1.2
-  peerDependencies:
-    "@babel/core": ^7.4.0-0
-  checksum: 8e3fe75513302e34f6d92bd67b53890e8545e6c5bca8fe757b9979f09d68d7e259f6daea90dc9e01e332c4f8781bda31c5fe551c82a277f9bc0bec007aed497c
-  languageName: node
-  linkType: hard
-
 "@babel/helper-define-polyfill-provider@npm:^0.4.0":
   version: 0.4.0
   resolution: "@babel/helper-define-polyfill-provider@npm:0.4.0"
@@ -613,6 +597,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.13.0
   checksum: 16e7a5f3bf2f2ac0ca032a70bf0ebd7e886d84dbb712b55c0643c04c495f0f221fbcbca14b5f8f8027fa6c87a3dafae0934022ad2b409384af6c5c356495b7bd
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-external-helpers@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/plugin-external-helpers@npm:7.22.5"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.22.5
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 3cd44da2eff95a83ea3d763737c0fb3ed92fcaf534c120bb550e064b1c9c70c3f45366b65b096584f0fbe759b2225860ff824108398e4fa7c76b041b2f529397
   languageName: node
   linkType: hard
 
@@ -1538,19 +1533,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-runtime@npm:^7.18.6":
-  version: 7.18.9
-  resolution: "@babel/plugin-transform-runtime@npm:7.18.9"
+"@babel/plugin-transform-runtime@npm:^7.18.6, @babel/plugin-transform-runtime@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/plugin-transform-runtime@npm:7.22.5"
   dependencies:
-    "@babel/helper-module-imports": ^7.18.6
-    "@babel/helper-plugin-utils": ^7.18.9
-    babel-plugin-polyfill-corejs2: ^0.3.1
-    babel-plugin-polyfill-corejs3: ^0.5.2
-    babel-plugin-polyfill-regenerator: ^0.3.1
+    "@babel/helper-module-imports": ^7.22.5
+    "@babel/helper-plugin-utils": ^7.22.5
+    babel-plugin-polyfill-corejs2: ^0.4.3
+    babel-plugin-polyfill-corejs3: ^0.8.1
+    babel-plugin-polyfill-regenerator: ^0.5.0
     semver: ^6.3.0
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: fc5e3c5c73197fabd165f85c2e0c4b156d5ef1dd724b28f73f1d000882692141ea13541a2df8067a93c2bd9b0aafe7e61911ac046f67808fcb2f252fb5f3eddd
+  checksum: 52cf177045b5f61a6cfc36b45aa7629586dc00a28371a09ef03e877a627f520efd51817ad8cceabaaa25f266e069859b36a5ac5018afeaa7f37aafa9325df4d8
   languageName: node
   linkType: hard
 
@@ -5561,7 +5556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:^0.5.0":
+"@swc/helpers@npm:^0.5.0, @swc/helpers@npm:^0.5.1":
   version: 0.5.1
   resolution: "@swc/helpers@npm:0.5.1"
   dependencies:
@@ -7444,19 +7439,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs2@npm:^0.3.1":
-  version: 0.3.3
-  resolution: "babel-plugin-polyfill-corejs2@npm:0.3.3"
-  dependencies:
-    "@babel/compat-data": ^7.17.7
-    "@babel/helper-define-polyfill-provider": ^0.3.3
-    semver: ^6.1.1
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 7db3044993f3dddb3cc3d407bc82e640964a3bfe22de05d90e1f8f7a5cb71460011ab136d3c03c6c1ba428359ebf635688cd6205e28d0469bba221985f5c6179
-  languageName: node
-  linkType: hard
-
 "babel-plugin-polyfill-corejs2@npm:^0.4.3":
   version: 0.4.3
   resolution: "babel-plugin-polyfill-corejs2@npm:0.4.3"
@@ -7470,18 +7452,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-polyfill-corejs3@npm:^0.5.2":
-  version: 0.5.3
-  resolution: "babel-plugin-polyfill-corejs3@npm:0.5.3"
-  dependencies:
-    "@babel/helper-define-polyfill-provider": ^0.3.2
-    core-js-compat: ^3.21.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 9c6644a1b0afbe59e402827fdafc6f44994ff92c5b2f258659cbbfd228f7075dea49e95114af10e66d70f36cbde12ff1d81263eb67be749b3ef0e2c18cf3c16d
-  languageName: node
-  linkType: hard
-
 "babel-plugin-polyfill-corejs3@npm:^0.8.1":
   version: 0.8.1
   resolution: "babel-plugin-polyfill-corejs3@npm:0.8.1"
@@ -7491,17 +7461,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: c23a581973c141a4687126cf964981180ef27e3eb0b34b911161db4f5caf9ba7ff60bee0ebe46d650ba09e03a6a3ac2cd6a6ae5f4f5363a148470e5cd8447df2
-  languageName: node
-  linkType: hard
-
-"babel-plugin-polyfill-regenerator@npm:^0.3.1":
-  version: 0.3.1
-  resolution: "babel-plugin-polyfill-regenerator@npm:0.3.1"
-  dependencies:
-    "@babel/helper-define-polyfill-provider": ^0.3.1
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: f1473df7b700d6795ca41301b1e65a0aff15ce6c1463fc0ce2cf0c821114b0330920f59d4cebf52976363ee817ba29ad2758544a4661a724b08191080b9fe1da
   languageName: node
   linkType: hard
 
@@ -9003,7 +8962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.21.0, core-js-compat@npm:^3.30.1, core-js-compat@npm:^3.30.2":
+"core-js-compat@npm:^3.30.1, core-js-compat@npm:^3.30.2":
   version: 3.30.2
   resolution: "core-js-compat@npm:3.30.2"
   dependencies:
@@ -17326,7 +17285,9 @@ __metadata:
   resolution: "packemon@workspace:packages/packemon"
   dependencies:
     "@babel/core": ^7.22.5
+    "@babel/plugin-external-helpers": ^7.22.5
     "@babel/plugin-proposal-decorators": ^7.22.5
+    "@babel/plugin-transform-runtime": ^7.22.5
     "@babel/preset-env": ^7.22.5
     "@babel/preset-flow": ^7.22.5
     "@babel/preset-react": ^7.22.5
@@ -17344,6 +17305,7 @@ __metadata:
     "@rollup/plugin-node-resolve": ^15.1.0
     "@swc/cli": ^0.1.62
     "@swc/core": ^1.3.64
+    "@swc/helpers": ^0.5.1
     "@typescript-eslint/types": ^5.59.11
     babel-plugin-cjs-esm-interop: ^3.0.1
     babel-plugin-conditional-invariant: ^3.0.1


### PR DESCRIPTION
This allows developers to enable swc on a per package basis, as well as control babel/swc helpers.