### PR TITLE
fix: remove possible overlaps in paths

### DIFF
--- a/packages/packemon/src/rollup/plugins/copyAndRefAssets.ts
+++ b/packages/packemon/src/rollup/plugins/copyAndRefAssets.ts
@@ -28,8 +28,11 @@ export interface CopyAssetsOptions {
 	dir: string;
 }
 
-export function copyAndRefAssets({ dir }: CopyAssetsOptions): Plugin {
-	const assetsToCopy: Record<string, VirtualPath> = {};
+export function copyAndRefAssets(
+	{ dir }: CopyAssetsOptions,
+	assetsToCopyInit: Record<string, VirtualPath> = {},
+): Plugin {
+	const assetsToCopy = assetsToCopyInit;
 
 	function determineNewAsset(source: string, importer?: string): VirtualPath {
 		let preparedImporter = importer ? path.dirname(importer) : '';

--- a/packages/packemon/tests/rollup/plugins/__fixtures__/src/components/AnotherComponent/anotherEntry.mjs
+++ b/packages/packemon/tests/rollup/plugins/__fixtures__/src/components/AnotherComponent/anotherEntry.mjs
@@ -1,0 +1,1 @@
+export const ae = 1;

--- a/packages/packemon/tests/rollup/plugins/__fixtures__/src/components/MyComponent/MySubComponent/bar.mjs
+++ b/packages/packemon/tests/rollup/plugins/__fixtures__/src/components/MyComponent/MySubComponent/bar.mjs
@@ -1,0 +1,3 @@
+import svg from './icons/test.svg';
+
+export const newSvg = `new: ${svg}`;

--- a/packages/packemon/tests/rollup/plugins/__fixtures__/src/components/MyComponent/MySubComponent/test.svg
+++ b/packages/packemon/tests/rollup/plugins/__fixtures__/src/components/MyComponent/MySubComponent/test.svg
@@ -1,0 +1,1 @@
+export default 'test.svg test contents';

--- a/packages/packemon/tests/rollup/plugins/__fixtures__/src/components/MyComponent/entry.mjs
+++ b/packages/packemon/tests/rollup/plugins/__fixtures__/src/components/MyComponent/entry.mjs
@@ -1,0 +1,5 @@
+// eslint-disable-next-line unicorn/prefer-module
+import { newSvg } from './MySubComponent/bar.mjs';
+
+console.log(newSvg);
+export const foo = 124;

--- a/packages/packemon/tests/rollup/plugins/copyAndRefAssets.test.ts
+++ b/packages/packemon/tests/rollup/plugins/copyAndRefAssets.test.ts
@@ -1,0 +1,59 @@
+import path from 'node:path';
+import { InputOption, rollup } from 'rollup';
+import { VirtualPath } from '@boost/common';
+import commonjs from '@rollup/plugin-commonjs';
+import { copyAndRefAssets } from '../../../src/rollup/plugins/copyAndRefAssets';
+
+async function transform(
+	input: InputOption,
+	assetsToCopy: Record<string, VirtualPath>,
+): Promise<string> {
+	const copyRefPlugin = copyAndRefAssets({ dir: '/root/fakeAssets' }, assetsToCopy);
+	copyRefPlugin.buildStart = () => Promise.resolve();
+	copyRefPlugin.generateBundle = () => Promise.resolve();
+
+	const bundle = await rollup({
+		input,
+		external: (id) => id.endsWith('.svg'), // treat .svg files as external
+		plugins: [commonjs(), copyRefPlugin],
+	});
+
+	const { output } = await bundle.generate({
+		dir: 'out',
+		format: 'cjs',
+	});
+
+	return output[0].code || '';
+}
+
+jest.mock('fs', () => {
+	const originalFs = jest.requireActual('fs');
+	return {
+		__esModule: true,
+		...originalFs,
+		mkdir: jest.fn(),
+		readFileSync: jest.fn((p, options) => {
+			if (typeof p === 'string' && p.endsWith('.svg')) {
+				return 'Mock SVG Content';
+			}
+			return originalFs.readFileSync(p, options);
+		}),
+	};
+});
+
+describe('copyAndRefAssets()', () => {
+	// eslint-disable-next-line unicorn/prefer-module
+	const fixturePath1 = path.join(__dirname, '__fixtures__/src/components/MyComponent/entry.mjs');
+	const fixturePath2 = path.join(
+		// eslint-disable-next-line unicorn/prefer-module
+		__dirname,
+		'__fixtures__/src/components/AnotherComponent/anotherEntry.mjs',
+	);
+	it('Should fix overlapping paths', async () => {
+		const assetsToCopy = {};
+		await transform({ another: fixturePath1, myComponent: fixturePath2 }, assetsToCopy);
+		expect(Object.keys(assetsToCopy)[0]).toMatch(
+			'packemon/tests/rollup/plugins/__fixtures__/src/components/MyComponent/MySubComponent/icons/test.svg',
+		);
+	});
+});


### PR DESCRIPTION
There's an issue caused by this line: https://github.com/milesj/packemon/blob/master/packages/packemon/src/rollup/plugins/copyAndRefAssets.ts#L87

chunk.facadeModuleId is not ideal because the bundled code gets moved up to the 
root (output) directory compared to where it was located in the source files, 
the imports in the source files that get bundled get changed to be relative 
to the new bundle location, but the chunk.facadeModuleId is the old location of 
the index. So, you have the old path + the new updated imports and there could be 
overlap due to this "hoisting", which has a workaround in determineNewAsset

There doesn't seem to be a better path to use, so this is a workaround that should hopefully fix this issue. Maybe there is a better way to solve this?